### PR TITLE
Servlet - Entry Replication

### DIFF
--- a/servlet/src/main/java/com/springRaft/servlet/communication/inbound/RESTController.java
+++ b/servlet/src/main/java/com/springRaft/servlet/communication/inbound/RESTController.java
@@ -40,7 +40,13 @@ public class RESTController implements InboundCommunication {
     )
     public ResponseEntity<AppendEntriesReply> appendEntriesEndpoint(@RequestBody AppendEntries appendEntries) {
 
-        return new ResponseEntity<>(this.appendEntries(appendEntries), HttpStatus.OK);
+        log.info(appendEntries.toString());
+
+        AppendEntriesReply reply = this.appendEntries(appendEntries);
+
+        log.info(reply.toString());
+
+        return new ResponseEntity<>(reply, HttpStatus.OK);
     }
 
     /**
@@ -54,7 +60,13 @@ public class RESTController implements InboundCommunication {
     )
     public ResponseEntity<RequestVoteReply> requestVoteEndpoint(@RequestBody RequestVote requestVote) {
 
-        return new ResponseEntity<>(this.requestVote(requestVote), HttpStatus.OK);
+        log.info(requestVote.toString());
+
+        RequestVoteReply reply = this.requestVote(requestVote);
+
+        log.info(reply.toString());
+
+        return new ResponseEntity<>(reply, HttpStatus.OK);
 
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/communication/message/AppendEntries.java
+++ b/servlet/src/main/java/com/springRaft/servlet/communication/message/AppendEntries.java
@@ -1,5 +1,6 @@
 package com.springRaft.servlet.communication.message;
 
+import com.springRaft.servlet.persistence.log.Entry;
 import lombok.*;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -28,9 +29,7 @@ public class AppendEntries implements Message {
     private Long prevLogTerm;
 
     /* Log entries to store (empty for heartbeat; may send more than one for efficiency) */
-    // IT SHOULD NOT BE STRING BUT ENTRY THAT DOESNT EXIST YET
-    // ...
-    private List<String> entries;
+    private List<Entry> entries;
 
     /* Leader’s commitIndex */
     private Long leaderCommit;

--- a/servlet/src/main/java/com/springRaft/servlet/communication/outbound/MessageSubscriber.java
+++ b/servlet/src/main/java/com/springRaft/servlet/communication/outbound/MessageSubscriber.java
@@ -1,5 +1,14 @@
 package com.springRaft.servlet.communication.outbound;
 
 public interface MessageSubscriber {
+
+    /**
+     * Notification of a new message for the subscribers.
+     * */
     void newMessage();
+
+    /**
+     * Notification to clear the remaining messages for the subscribers.
+     * */
+    void clearMessages();
 }

--- a/servlet/src/main/java/com/springRaft/servlet/communication/outbound/OutboundManager.java
+++ b/servlet/src/main/java/com/springRaft/servlet/communication/outbound/OutboundManager.java
@@ -29,4 +29,9 @@ public class OutboundManager {
             subscriber.newMessage();
     }
 
+    public void clearMessages() {
+        for(MessageSubscriber subscriber : this.subscribers)
+            subscriber.clearMessages();
+    }
+
 }

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Candidate.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Candidate.java
@@ -74,7 +74,7 @@ public class Candidate extends RaftStateContext implements RaftState {
     }
 
     @Override
-    public void appendEntriesReply(AppendEntriesReply appendEntriesReply) {
+    public void appendEntriesReply(AppendEntriesReply appendEntriesReply, String from) {
 
         // If receive AppendEntries replies when in candidate state there
         // is nothing to do

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Candidate.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Candidate.java
@@ -206,25 +206,14 @@ public class Candidate extends RaftStateContext implements RaftState {
     /* --------------------------------------------------- */
 
     /**
-     * A method that encapsulates replicated code, and has the function of setting
-     * the reply for the received AppendEntries.
+     * Implementation of the postAppendEntries abstract method in parent class.
+     * This method contains the behaviour to execute after invoking appendEntries method.
      *
      * @param appendEntries The received AppendEntries communication.
-     * @param reply AppendEntriesReply object, to send as response to the leader.
      * */
-    protected void setAppendEntriesReply(AppendEntries appendEntries, AppendEntriesReply reply) {
+    protected void postAppendEntries(AppendEntries appendEntries) {
 
         this.cleanBeforeTransit();
-
-        // reply with the current term
-        reply.setTerm(appendEntries.getTerm());
-
-        // check reply's success based on prevLogIndex and prevLogTerm
-        // reply.setSuccess()
-        // ...
-        // ...
-        // this need to be changed
-        reply.setSuccess(true);
 
         // transit to follower state
         this.transitionManager.setNewFollowerState();

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Candidate.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Candidate.java
@@ -7,6 +7,7 @@ import com.springRaft.servlet.persistence.log.LogService;
 import com.springRaft.servlet.persistence.log.LogState;
 import com.springRaft.servlet.persistence.state.State;
 import com.springRaft.servlet.persistence.state.StateService;
+import com.springRaft.servlet.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
@@ -147,9 +148,9 @@ public class Candidate extends RaftStateContext implements RaftState {
     }
 
     @Override
-    public Message getNextMessage(String to) {
+    public Pair<Message, Boolean> getNextMessage(String to) {
 
-        return this.requestVoteMessage;
+        return new Pair<>(this.requestVoteMessage, false);
 
     }
 
@@ -255,7 +256,7 @@ public class Candidate extends RaftStateContext implements RaftState {
 
         // change message to null and notify peer workers
         this.requestVoteMessage = null;
-        this.outboundManager.newMessage();
+        this.outboundManager.clearMessages();
 
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/ConsensusModule.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/ConsensusModule.java
@@ -1,6 +1,7 @@
 package com.springRaft.servlet.consensusModule;
 
 import com.springRaft.servlet.communication.message.*;
+import com.springRaft.servlet.util.Pair;
 import lombok.Getter;
 import lombok.Synchronized;
 import org.springframework.context.annotation.Scope;
@@ -58,7 +59,7 @@ public class ConsensusModule implements RaftState {
 
     @Override
     @Synchronized
-    public Message getNextMessage(String to) {
+    public Pair<Message, Boolean> getNextMessage(String to) {
         return this.current.getNextMessage(to);
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/ConsensusModule.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/ConsensusModule.java
@@ -41,8 +41,8 @@ public class ConsensusModule implements RaftState {
 
     @Override
     @Synchronized
-    public void appendEntriesReply(AppendEntriesReply appendEntriesReply) {
-        this.current.appendEntriesReply(appendEntriesReply);
+    public void appendEntriesReply(AppendEntriesReply appendEntriesReply, String from) {
+        this.current.appendEntriesReply(appendEntriesReply, from);
     }
 
     @Override

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Follower.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Follower.java
@@ -68,7 +68,7 @@ public class Follower extends RaftStateContext implements RaftState {
     }
 
     @Override
-    public void appendEntriesReply(AppendEntriesReply appendEntriesReply) {
+    public void appendEntriesReply(AppendEntriesReply appendEntriesReply, String from) {
 
         // If receive AppendEntries replies when in follower state there
         // is nothing to do

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Follower.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Follower.java
@@ -5,6 +5,7 @@ import com.springRaft.servlet.communication.outbound.OutboundManager;
 import com.springRaft.servlet.config.RaftProperties;
 import com.springRaft.servlet.persistence.log.LogService;
 import com.springRaft.servlet.persistence.state.StateService;
+import com.springRaft.servlet.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
@@ -136,8 +137,8 @@ public class Follower extends RaftStateContext implements RaftState {
     }
 
     @Override
-    public Message getNextMessage(String to) {
-        return null;
+    public Pair<Message, Boolean> getNextMessage(String to) {
+        return new Pair<>(null, false);
     }
 
     @Override

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Follower.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Follower.java
@@ -3,7 +3,9 @@ package com.springRaft.servlet.consensusModule;
 import com.springRaft.servlet.communication.message.*;
 import com.springRaft.servlet.communication.outbound.OutboundManager;
 import com.springRaft.servlet.config.RaftProperties;
+import com.springRaft.servlet.persistence.log.Entry;
 import com.springRaft.servlet.persistence.log.LogService;
+import com.springRaft.servlet.persistence.log.LogState;
 import com.springRaft.servlet.persistence.state.StateService;
 import com.springRaft.servlet.util.Pair;
 import org.slf4j.Logger;
@@ -180,14 +182,66 @@ public class Follower extends RaftStateContext implements RaftState {
         reply.setTerm(appendEntries.getTerm());
 
         // check reply's success based on prevLogIndex and prevLogTerm
-        // reply.setSuccess()
-        // ...
-        // ...
-        // this need to be changed
-        reply.setSuccess(true);
+        Entry entry = this.logService.getEntryByIndex(appendEntries.getPrevLogIndex());
+        entry = entry == null ? new Entry((long) 0, (long) 0, null) : entry;
+
+        if(entry.getIndex() == (long) appendEntries.getPrevLogIndex()) {
+
+            if (entry.getTerm() == (long) appendEntries.getTerm()) {
+
+                reply.setSuccess(true);
+
+                this.applyAppendEntries(appendEntries);
+
+            } else {
+
+                reply.setSuccess(false);
+
+            }
+
+        } else {
+
+            reply.setSuccess(false);
+
+        }
 
         // set a new timeout, it's equivalent to transit to a new follower state
         this.setTimeout();
+
+    }
+
+    private void applyAppendEntries(AppendEntries appendEntries) {
+
+        if (appendEntries.getEntries().size() != 0) {
+
+            // delete all the following conflict entries
+            this.logService.deleteIndexesGreaterThan(appendEntries.getPrevLogIndex());
+
+            // insert new entry
+            Entry newEntry = new Entry(appendEntries.getTerm(), appendEntries.getEntries().get(0));
+            newEntry = this.logService.insertEntry(newEntry);
+
+            LogState logState = this.logService.getState();
+            if (appendEntries.getLeaderCommit() > logState.getCommittedIndex()) {
+
+                if (newEntry.getIndex() <= appendEntries.getLeaderCommit()) {
+
+                    logState.setCommittedIndex(newEntry.getIndex());
+                    logState.setCommittedTerm(newEntry.getTerm());
+                    this.logService.saveState(logState);
+
+                } else {
+
+                    long index = appendEntries.getLeaderCommit();
+                    Entry entry = this.logService.getEntryByIndex(index);
+                    logState.setCommittedIndex(entry.getIndex());
+                    logState.setCommittedTerm(entry.getTerm());
+
+                }
+
+            }
+
+        }
 
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Follower.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Follower.java
@@ -210,6 +210,11 @@ public class Follower extends RaftStateContext implements RaftState {
 
     }
 
+    /**
+     * Method for insert new entries in log and update the committed values in log state.
+     *
+     * @param appendEntries The received AppendEntries communication.
+     * */
     private void applyAppendEntries(AppendEntries appendEntries) {
 
         if (appendEntries.getEntries().size() != 0) {
@@ -221,6 +226,7 @@ public class Follower extends RaftStateContext implements RaftState {
             Entry newEntry = new Entry(appendEntries.getTerm(), appendEntries.getEntries().get(0));
             newEntry = this.logService.insertEntry(newEntry);
 
+            // update committed entries in LogState
             LogState logState = this.logService.getState();
             if (appendEntries.getLeaderCommit() > logState.getCommittedIndex()) {
 

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Leader.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Leader.java
@@ -223,7 +223,7 @@ public class Leader extends RaftStateContext implements RaftState {
     /* --------------------------------------------------- */
 
     @Override
-    protected void setAppendEntriesReply(AppendEntries appendEntries, AppendEntriesReply reply) {
+    protected void postAppendEntries(AppendEntries appendEntries) {
         // not needed in Leader
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/RaftState.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/RaftState.java
@@ -18,8 +18,9 @@ public interface RaftState {
      * Method for handling AppendEntries replies.
      *
      * @param appendEntriesReply AppendEntriesReply object sent from other servers.
+     * @param from String that identifies the server that sent the reply.
      * */
-    void appendEntriesReply(AppendEntriesReply appendEntriesReply);
+    void appendEntriesReply(AppendEntriesReply appendEntriesReply, String from);
 
     /**
      * Method for handling RequestVote RPC.

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/RaftState.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/RaftState.java
@@ -1,6 +1,7 @@
 package com.springRaft.servlet.consensusModule;
 
 import com.springRaft.servlet.communication.message.*;
+import com.springRaft.servlet.util.Pair;
 
 public interface RaftState {
 
@@ -41,9 +42,10 @@ public interface RaftState {
      *
      * @param to String that represents the server.
      *
-     * @return Message to send to the server.
+     * @return Pair<Message, Boolean> Message to send to the target server and a boolean that signals
+     *      if this message is a heartbeat.
      * */
-    Message getNextMessage(String to);
+    Pair<Message, Boolean> getNextMessage(String to);
 
     /**
      * Method for doing the work that it's required on startup.

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/RaftStateContext.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/RaftStateContext.java
@@ -141,9 +141,11 @@ public abstract class RaftStateContext {
         Entry entry = this.logService.getEntryByIndex(appendEntries.getPrevLogIndex());
         entry = entry == null ? new Entry((long) 0, (long) 0, null) : entry;
 
+        System.out.println("\n\n" + entry.toString() + "\n" + appendEntries.toString() + "\n\n");
+
         if(entry.getIndex() == (long) appendEntries.getPrevLogIndex()) {
 
-            if (entry.getTerm() == (long) appendEntries.getTerm()) {
+            if (entry.getTerm() == (long) appendEntries.getPrevLogTerm()) {
 
                 reply.setSuccess(true);
 
@@ -176,7 +178,7 @@ public abstract class RaftStateContext {
             this.logService.deleteIndexesGreaterThan(appendEntries.getPrevLogIndex());
 
             // insert new entry
-            Entry newEntry = new Entry(appendEntries.getTerm(), appendEntries.getEntries().get(0));
+            Entry newEntry = new Entry(appendEntries.getEntries().get(0).getTerm(), appendEntries.getEntries().get(0).getCommand());
             newEntry = this.logService.insertEntry(newEntry);
 
             // update committed entries in LogState

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/RaftStateContext.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/RaftStateContext.java
@@ -141,8 +141,6 @@ public abstract class RaftStateContext {
         Entry entry = this.logService.getEntryByIndex(appendEntries.getPrevLogIndex());
         entry = entry == null ? new Entry((long) 0, (long) 0, null) : entry;
 
-        System.out.println("\n\n" + entry.toString() + "\n" + appendEntries.toString() + "\n\n");
-
         if(entry.getIndex() == (long) appendEntries.getPrevLogIndex()) {
 
             if (entry.getTerm() == (long) appendEntries.getPrevLogTerm()) {

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/RaftStateContext.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/RaftStateContext.java
@@ -6,6 +6,7 @@ import com.springRaft.servlet.communication.message.RequestVote;
 import com.springRaft.servlet.communication.message.RequestVoteReply;
 import com.springRaft.servlet.communication.outbound.OutboundManager;
 import com.springRaft.servlet.config.RaftProperties;
+import com.springRaft.servlet.persistence.log.Entry;
 import com.springRaft.servlet.persistence.log.LogService;
 import com.springRaft.servlet.persistence.log.LogState;
 import com.springRaft.servlet.persistence.state.StateService;
@@ -95,7 +96,10 @@ public abstract class RaftStateContext {
 
     /* --------------------------------------------------- */
 
-    public AppendEntriesReply appendEntries(AppendEntries appendEntries) {
+    /**
+     * TODO
+     * */
+    protected AppendEntriesReply appendEntries(AppendEntries appendEntries) {
 
         AppendEntriesReply reply = this.applicationContext.getBean(AppendEntriesReply.class);
 
@@ -106,16 +110,15 @@ public abstract class RaftStateContext {
             reply.setTerm(currentTerm);
             reply.setSuccess(false);
 
-        } else if (appendEntries.getTerm() > currentTerm) {
+        } else {
 
-            // update term
-            this.stateService.setState(appendEntries.getTerm(), null);
-
-            this.setAppendEntriesReply(appendEntries, reply);
-
-        } else if (appendEntries.getTerm() == currentTerm) {
+            if (appendEntries.getTerm() > currentTerm) {
+                // update term
+                this.stateService.setState(appendEntries.getTerm(), null);
+            }
 
             this.setAppendEntriesReply(appendEntries, reply);
+            this.postAppendEntries(appendEntries);
 
         }
 
@@ -123,6 +126,91 @@ public abstract class RaftStateContext {
 
     }
 
-    protected abstract void setAppendEntriesReply(AppendEntries appendEntries, AppendEntriesReply reply);
+    /**
+     * A method that encapsulates replicated code, and has the function of setting
+     * the reply for the received AppendEntries.
+     *
+     * @param appendEntries The received AppendEntries communication.
+     * @param reply AppendEntriesReply object, to send as response to the leader.
+     * */
+    private void setAppendEntriesReply(AppendEntries appendEntries, AppendEntriesReply reply) {
+
+        // reply with the current term
+        reply.setTerm(appendEntries.getTerm());
+
+        Entry entry = this.logService.getEntryByIndex(appendEntries.getPrevLogIndex());
+        entry = entry == null ? new Entry((long) 0, (long) 0, null) : entry;
+
+        if(entry.getIndex() == (long) appendEntries.getPrevLogIndex()) {
+
+            if (entry.getTerm() == (long) appendEntries.getTerm()) {
+
+                reply.setSuccess(true);
+
+                this.applyAppendEntries(appendEntries);
+
+            } else {
+
+                reply.setSuccess(false);
+
+            }
+
+        } else {
+
+            reply.setSuccess(false);
+
+        }
+
+    }
+
+    /**
+     * Method for insert new entries in log and update the committed values in log state.
+     *
+     * @param appendEntries The received AppendEntries communication.
+     * */
+    private void applyAppendEntries(AppendEntries appendEntries) {
+
+        if (appendEntries.getEntries().size() != 0) {
+
+            // delete all the following conflict entries
+            this.logService.deleteIndexesGreaterThan(appendEntries.getPrevLogIndex());
+
+            // insert new entry
+            Entry newEntry = new Entry(appendEntries.getTerm(), appendEntries.getEntries().get(0));
+            newEntry = this.logService.insertEntry(newEntry);
+
+            // update committed entries in LogState
+            LogState logState = this.logService.getState();
+            if (appendEntries.getLeaderCommit() > logState.getCommittedIndex()) {
+
+                if (newEntry.getIndex() <= appendEntries.getLeaderCommit()) {
+
+                    logState.setCommittedIndex(newEntry.getIndex());
+                    logState.setCommittedTerm(newEntry.getTerm());
+                    this.logService.saveState(logState);
+
+                } else {
+
+                    long index = appendEntries.getLeaderCommit();
+                    Entry entry = this.logService.getEntryByIndex(index);
+                    logState.setCommittedIndex(entry.getIndex());
+                    logState.setCommittedTerm(entry.getTerm());
+
+                }
+
+            }
+
+        }
+
+    }
+
+    /**
+     * Abstract method for the Raft state to implement it for post execution operations.
+     *
+     * @param appendEntries The received AppendEntries communication.
+     * */
+    protected abstract void postAppendEntries(AppendEntries appendEntries);
+
+    /* --------------------------------------------------- */
 
 }

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/TransitionManager.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/TransitionManager.java
@@ -2,8 +2,6 @@ package com.springRaft.servlet.consensusModule;
 
 import com.springRaft.servlet.config.RaftProperties;
 import com.springRaft.servlet.worker.StateTransition;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -16,9 +14,6 @@ import java.util.concurrent.ScheduledFuture;
 
 @Service
 public class TransitionManager {
-
-    /* Logger */
-    private static final Logger log = LoggerFactory.getLogger(TransitionManager.class);
 
     /* Context for getting the appropriate Beans */
     private final ApplicationContext applicationContext;
@@ -64,8 +59,6 @@ public class TransitionManager {
         );
 
         Date date = new Date(System.currentTimeMillis() + timeout);
-
-        log.info("Set an election timeout: " + timeout + "ms");
 
         // schedule task
         return this.threadPoolTaskScheduler.schedule(transition, date);

--- a/servlet/src/main/java/com/springRaft/servlet/persistence/log/EntryRepository.java
+++ b/servlet/src/main/java/com/springRaft/servlet/persistence/log/EntryRepository.java
@@ -8,12 +8,20 @@ import org.springframework.stereotype.Repository;
 public interface EntryRepository extends JpaRepository<Entry,Long> {
 
     /**
-     * Select method for find the last entry in the log.
+     * Select method for find the last entry's index in the log.
      *
      * @return Long Index of the last entry.
      * */
     @Query("SELECT MAX(entry.index) FROM Entry entry")
-    Long findLastEntry();
+    Long findLastEntryIndex();
+
+    /**
+     * Select method for getting the last entry in the log.
+     *
+     * @return Entry Last log entry.
+     * */
+    @Query("SELECT entry FROM Entry entry WHERE entry.index = (SELECT MAX(entry.index) FROM Entry entry)")
+    Entry findLastEntry();
 
     /**
      * Delete Method for deleting entries with an index greater than a specific number.

--- a/servlet/src/main/java/com/springRaft/servlet/persistence/log/EntryRepository.java
+++ b/servlet/src/main/java/com/springRaft/servlet/persistence/log/EntryRepository.java
@@ -27,9 +27,7 @@ public interface EntryRepository extends JpaRepository<Entry,Long> {
      * Delete Method for deleting entries with an index greater than a specific number.
      *
      * @param index Long that represents the index from which the following will be deleted.
-     *
-     * @return int Number of deleted entries.
      * */
-    int deleteEntryByIndexGreaterThan(Long index);
+    void deleteEntryByIndexGreaterThan(Long index);
 
 }

--- a/servlet/src/main/java/com/springRaft/servlet/persistence/log/LogService.java
+++ b/servlet/src/main/java/com/springRaft/servlet/persistence/log/LogService.java
@@ -2,8 +2,10 @@ package com.springRaft.servlet.persistence.log;
 
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @AllArgsConstructor
 public class LogService {
 

--- a/servlet/src/main/java/com/springRaft/servlet/persistence/log/LogService.java
+++ b/servlet/src/main/java/com/springRaft/servlet/persistence/log/LogService.java
@@ -109,9 +109,9 @@ public class LogService {
     /**
      * TODO
      * */
-    public Integer deleteIndexesGreaterThan(Long index) {
+    public void deleteIndexesGreaterThan(Long index) {
 
-        return this.entryRepository.deleteEntryByIndexGreaterThan(index);
+        this.entryRepository.deleteEntryByIndexGreaterThan(index);
 
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/persistence/log/LogService.java
+++ b/servlet/src/main/java/com/springRaft/servlet/persistence/log/LogService.java
@@ -29,7 +29,7 @@ public class LogService {
     /**
      * TODO
      * */
-    public Entry getIndex(Long index) {
+    public Entry getEntryByIndex(Long index) {
 
         return this.entryRepository
                 .findById(index)
@@ -40,10 +40,22 @@ public class LogService {
     /**
      * TODO
      * */
-    public Long getLastEntry() {
+    public Long getLastEntryIndex() {
 
-        Long index = this.entryRepository.findLastEntry();
+        Long index = this.entryRepository.findLastEntryIndex();
         return index == null ? (long) 0 : index;
+
+    }
+
+    /**
+     * TODO
+     * */
+    public Entry getLastEntry() {
+
+        Entry entry = this.entryRepository.findLastEntry();
+        return entry == null
+                ? new Entry((long) 0, (long) 0, null)
+                : entry;
 
     }
 
@@ -52,7 +64,7 @@ public class LogService {
      * */
     public Entry insertEntry(Entry entry) {
 
-        Long lastIndex = this.getLastEntry();
+        Long lastIndex = this.getLastEntryIndex();
         entry.setIndex(lastIndex + 1);
         return this.entryRepository.save(entry);
 

--- a/servlet/src/main/java/com/springRaft/servlet/persistence/state/StateService.java
+++ b/servlet/src/main/java/com/springRaft/servlet/persistence/state/StateService.java
@@ -2,8 +2,10 @@ package com.springRaft.servlet.persistence.state;
 
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @AllArgsConstructor
 public class StateService {
 

--- a/servlet/src/main/java/com/springRaft/servlet/util/Pair.java
+++ b/servlet/src/main/java/com/springRaft/servlet/util/Pair.java
@@ -1,0 +1,67 @@
+package com.springRaft.servlet.util;
+
+import java.util.Objects;
+
+public class Pair<F,S> {
+
+    /* First element of the pair */
+    private final F first;
+
+    /* Second element of the pair */
+    private final S second;
+
+    /* --------------------------------------------------- */
+
+    /**
+     * Parameterized constructor for Pair
+     * */
+    public Pair(F first, S second){
+        this.first = first;
+        this.second = second;
+    }
+
+    /* --------------------------------------------------- */
+
+    /**
+     * Method that gets the first element of a pair
+     *
+     * @return F Object that represents the first element of the pair
+     * */
+    public F getFirst() {
+        return this.first;
+    }
+
+    /**
+     * Method that gets the second element of a pair
+     *
+     * @return F Object that represents the second element of the pair
+     * */
+    public S getSecond() {
+        return this.second;
+    }
+
+    /* --------------------------------------------------- */
+
+    /**
+     * Method that tests if a Pair is equal to another Pair
+     *
+     * @return boolean Boolean that represents the status of the operation.
+     * */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Pair<?, ?> pair = (Pair<?, ?>) o;
+        return getFirst().equals(pair.getFirst()) && getSecond().equals(pair.getSecond());
+    }
+
+    /**
+     * Method that calculates the hash of a Pair.
+     *
+     * @return int Integer that represents the hash of a Pair.
+     * */
+    @Override
+    public int hashCode() {
+        return Objects.hash(getFirst(), getSecond());
+    }
+}

--- a/servlet/src/main/java/com/springRaft/servlet/util/Pair.java
+++ b/servlet/src/main/java/com/springRaft/servlet/util/Pair.java
@@ -1,7 +1,10 @@
 package com.springRaft.servlet.util;
 
-import java.util.Objects;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
 
+@Component
+@Scope("prototype")
 public class Pair<F,S> {
 
     /* First element of the pair */
@@ -13,7 +16,7 @@ public class Pair<F,S> {
     /* --------------------------------------------------- */
 
     /**
-     * Parameterized constructor for Pair
+     * Parameterized constructor for Pair.
      * */
     public Pair(F first, S second){
         this.first = first;
@@ -23,45 +26,21 @@ public class Pair<F,S> {
     /* --------------------------------------------------- */
 
     /**
-     * Method that gets the first element of a pair
+     * Method that gets the first element of a pair.
      *
-     * @return F Object that represents the first element of the pair
+     * @return F Object that represents the first element of the pair.
      * */
     public F getFirst() {
         return this.first;
     }
 
     /**
-     * Method that gets the second element of a pair
+     * Method that gets the second element of a pair.
      *
-     * @return F Object that represents the second element of the pair
+     * @return S Object that represents the second element of the pair.
      * */
     public S getSecond() {
         return this.second;
     }
 
-    /* --------------------------------------------------- */
-
-    /**
-     * Method that tests if a Pair is equal to another Pair
-     *
-     * @return boolean Boolean that represents the status of the operation.
-     * */
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Pair<?, ?> pair = (Pair<?, ?>) o;
-        return getFirst().equals(pair.getFirst()) && getSecond().equals(pair.getSecond());
-    }
-
-    /**
-     * Method that calculates the hash of a Pair.
-     *
-     * @return int Integer that represents the hash of a Pair.
-     * */
-    @Override
-    public int hashCode() {
-        return Objects.hash(getFirst(), getSecond());
-    }
 }

--- a/servlet/src/main/java/com/springRaft/servlet/worker/PeerWorker.java
+++ b/servlet/src/main/java/com/springRaft/servlet/worker/PeerWorker.java
@@ -201,10 +201,7 @@ public class PeerWorker implements Runnable, MessageSubscriber {
 
         try {
 
-            RequestVoteReply reply = this.outbound.requestVote(this.targetServerName, requestVote);
-            log.info(reply.toString());
-
-            return reply;
+            return this.outbound.requestVote(this.targetServerName, requestVote);
 
         } catch (ExecutionException e) {
             // If target server is not alive
@@ -289,10 +286,7 @@ public class PeerWorker implements Runnable, MessageSubscriber {
 
         try {
 
-            AppendEntriesReply reply = this.outbound.appendEntries(this.targetServerName, appendEntries);
-            log.info(reply.toString());
-
-            return reply;
+            return this.outbound.appendEntries(this.targetServerName, appendEntries);
 
         } catch (ExecutionException e) {
             // If target server is not alive

--- a/servlet/src/main/java/com/springRaft/servlet/worker/PeerWorker.java
+++ b/servlet/src/main/java/com/springRaft/servlet/worker/PeerWorker.java
@@ -185,8 +185,10 @@ public class PeerWorker implements Runnable, MessageSubscriber {
             reply = this.sendRequestVote(message);
         } while (reply == null && this.active && this.remainingMessages == 0);
 
-        if (reply != null && this.active)
+        if (reply != null && this.active) {
             this.consensusModule.requestVoteReply(reply);
+            this.clearMessages();
+        }
 
     }
 
@@ -243,7 +245,7 @@ public class PeerWorker implements Runnable, MessageSubscriber {
 
             if (reply != null && this.active) {
 
-                this.consensusModule.appendEntriesReply(reply);
+                this.consensusModule.appendEntriesReply(reply, this.targetServerName);
 
                 // sleep for the remaining time, if any
                 this.waitOnConditionForAnAmountOfTime(start);
@@ -266,9 +268,9 @@ public class PeerWorker implements Runnable, MessageSubscriber {
 
             reply = this.sendAppendEntries(appendEntries);
 
-            if (reply != null) {
+            if (reply != null && this.active) {
 
-                this.consensusModule.appendEntriesReply(reply);
+                this.consensusModule.appendEntriesReply(reply, this.targetServerName);
                 break;
 
             }


### PR DESCRIPTION
This PR adds:

- AppendEntries Message carries Entries instead of Strings;
- Introduce method to switch off the PeerWorker when a state transition occur;
- Introduction of a mechanism (Pair<F,S>) that makes it possible to distinguish between message types (Heartbeats and normal AppendEntries);
- Calculation of the next message to send to a given server;
- Handling of AppendEntries replies;
- Logging is composed of requests and replies in RESTController;