### PR TITLE
Servlet - Apply Committed Entries to State Machine

### DIFF
--- a/servlet/src/main/java/com/springRaft/servlet/communication/outbound/OutboundManager.java
+++ b/servlet/src/main/java/com/springRaft/servlet/communication/outbound/OutboundManager.java
@@ -1,18 +1,17 @@
 package com.springRaft.servlet.communication.outbound;
 
-import lombok.AllArgsConstructor;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @Scope("singleton")
-@AllArgsConstructor
 public class OutboundManager {
 
     /* List of message subscribers */
-    private final List<MessageSubscriber> subscribers;
+    private final List<MessageSubscriber> subscribers = new ArrayList<>();
 
     /* --------------------------------------------------- */
 

--- a/servlet/src/main/java/com/springRaft/servlet/config/RaftProperties.java
+++ b/servlet/src/main/java/com/springRaft/servlet/config/RaftProperties.java
@@ -1,6 +1,5 @@
 package com.springRaft.servlet.config;
 
-import com.springRaft.servlet.consensusModule.Candidate;
 import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,6 +28,7 @@ public class RaftProperties {
     /* List of Addresses of cluster */
     private final List<InetSocketAddress> cluster;
 
+    /* Majority of members from a peer set */
     private final Integer quorum;
 
     /* Minimum Timeout to trigger an election */

--- a/servlet/src/main/java/com/springRaft/servlet/config/ThreadPools.java
+++ b/servlet/src/main/java/com/springRaft/servlet/config/ThreadPools.java
@@ -12,41 +12,26 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 public class ThreadPools {
 
     /**
-     * Thread Pool for state machine thread
+     * Thread Pool for general purpose workers.
      *
-     * @return TaskExecutor dedicated to state machine threads
+     * @return TaskExecutor general purpose threads.
      * */
-    @Bean(name = "stateMachineTaskExecutor")
-    public TaskExecutor stateMachineTaskExecutor() {
+    @Bean(name = "generalPurposeExecutor")
+    public TaskExecutor generalPurposeExecutor() {
 
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(1);
-        executor.setMaxPoolSize(1);
-        executor.setThreadNamePrefix("FSMTask-");
+        executor.setMaxPoolSize(5);
+        executor.setThreadNamePrefix("GeneralWorker-");
         executor.initialize();
 
         return executor;
     }
 
     /**
-     * Thread Pool for scheduled tasks
+     * Thread Pool for peer workers.
      *
-     * @return ThreadPoolTaskScheduler dedicated to timers
-     * */
-    @Bean(name = "transitionTaskExecutor")
-    public ThreadPoolTaskScheduler transitionTaskExecutor(){
-
-        ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
-        threadPoolTaskScheduler.setPoolSize(1);
-        threadPoolTaskScheduler.setThreadNamePrefix("TransitionTask-");
-
-        return threadPoolTaskScheduler;
-    }
-
-    /**
-     * Thread Pool for peer workers
-     *
-     * @return TaskExecutor dedicated to requests
+     * @return TaskExecutor dedicated to PeerWorker runnables.
      * */
     @Bean(name = "peerWorkersExecutor")
     public TaskExecutor peerWorkersTaskExecutor() {
@@ -61,9 +46,9 @@ public class ThreadPools {
     }
 
     /**
-     * Thread Pool for async requests
+     * Thread Pool for async requests.
      *
-     * @return TaskExecutor dedicated to requests
+     * @return TaskExecutor dedicated to requests.
      * */
     @Bean(name = "requestsExecutor")
     public TaskExecutor threadPoolTaskExecutor() {
@@ -76,4 +61,37 @@ public class ThreadPools {
 
         return executor;
     }
+
+    /**
+     * Thread Pool for state machine thread.
+     *
+     * @return TaskExecutor dedicated to StateMachineWorker runnable.
+     * */
+    @Bean(name = "stateMachineTaskExecutor")
+    public TaskExecutor stateMachineTaskExecutor() {
+
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(1);
+        executor.setThreadNamePrefix("FSMTask-");
+        executor.initialize();
+
+        return executor;
+    }
+
+    /**
+     * Thread Pool for scheduled tasks.
+     *
+     * @return ThreadPoolTaskScheduler dedicated to timers.
+     * */
+    @Bean(name = "transitionTaskExecutor")
+    public ThreadPoolTaskScheduler transitionTaskExecutor(){
+
+        ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+        threadPoolTaskScheduler.setPoolSize(1);
+        threadPoolTaskScheduler.setThreadNamePrefix("TransitionTask-");
+
+        return threadPoolTaskScheduler;
+    }
+
 }

--- a/servlet/src/main/java/com/springRaft/servlet/config/startup/PeerWorkers.java
+++ b/servlet/src/main/java/com/springRaft/servlet/config/startup/PeerWorkers.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Component;
 import java.net.InetSocketAddress;
 
 @Component
-@Order(1)
+@Order(2)
 public class PeerWorkers implements ApplicationRunner {
 
     /* Application Context for getting beans */

--- a/servlet/src/main/java/com/springRaft/servlet/config/startup/StateMachine.java
+++ b/servlet/src/main/java/com/springRaft/servlet/config/startup/StateMachine.java
@@ -1,8 +1,6 @@
 package com.springRaft.servlet.config.startup;
 
-import com.springRaft.servlet.consensusModule.ConsensusModule;
-import com.springRaft.servlet.consensusModule.Follower;
-import com.springRaft.servlet.worker.StateTransition;
+import com.springRaft.servlet.worker.StateMachineWorker;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.ApplicationArguments;
@@ -13,40 +11,33 @@ import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Component;
 
 @Component
-@Order(3)
-public class Initialization implements ApplicationRunner {
+@Order(2)
+public class StateMachine implements ApplicationRunner {
 
     /* Application Context for getting beans */
     private final ApplicationContext applicationContext;
 
-    /* Module that has the consensus functions to invoke */
-    private final ConsensusModule consensusModule;
-
-    /* Task Executor for submit workers to execution */
+    /* Task Executor for submit worker for execution */
     private final TaskExecutor taskExecutor;
 
     /* --------------------------------------------------- */
 
     @Autowired
-    public Initialization(
+    public StateMachine(
             ApplicationContext applicationContext,
-            ConsensusModule consensusModule,
-            @Qualifier(value = "generalPurposeExecutor") TaskExecutor taskExecutor
+            @Qualifier(value = "stateMachineTaskExecutor") TaskExecutor taskExecutor
     ) {
-
         this.applicationContext = applicationContext;
-        this.consensusModule = consensusModule;
         this.taskExecutor = taskExecutor;
-
     }
 
     /* --------------------------------------------------- */
 
     @Override
     public void run(ApplicationArguments args) {
-        StateTransition transition = applicationContext
-                .getBean(StateTransition.class, applicationContext, consensusModule, Follower.class);
-        taskExecutor.execute(transition);
-    }
 
+        StateMachineWorker worker = this.applicationContext.getBean(StateMachineWorker.class);
+        this.taskExecutor.execute(worker);
+
+    }
 }

--- a/servlet/src/main/java/com/springRaft/servlet/config/startup/StateMachine.java
+++ b/servlet/src/main/java/com/springRaft/servlet/config/startup/StateMachine.java
@@ -1,5 +1,7 @@
 package com.springRaft.servlet.config.startup;
 
+import com.springRaft.servlet.stateMachine.IndependentServer;
+import com.springRaft.servlet.stateMachine.StateMachineStrategy;
 import com.springRaft.servlet.worker.StateMachineWorker;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -37,6 +39,8 @@ public class StateMachine implements ApplicationRunner {
     public void run(ApplicationArguments args) {
 
         StateMachineWorker worker = this.applicationContext.getBean(StateMachineWorker.class);
+        StateMachineStrategy strategy = this.applicationContext.getBean(IndependentServer.class);
+        worker.setStrategy(strategy);
         this.taskExecutor.execute(worker);
 
     }

--- a/servlet/src/main/java/com/springRaft/servlet/config/startup/StateMachine.java
+++ b/servlet/src/main/java/com/springRaft/servlet/config/startup/StateMachine.java
@@ -1,5 +1,6 @@
 package com.springRaft.servlet.config.startup;
 
+import com.springRaft.servlet.stateMachine.CommitmentPublisher;
 import com.springRaft.servlet.stateMachine.IndependentServer;
 import com.springRaft.servlet.stateMachine.StateMachineStrategy;
 import com.springRaft.servlet.worker.StateMachineWorker;
@@ -40,11 +41,17 @@ public class StateMachine implements ApplicationRunner {
 
         StateMachineWorker worker = this.applicationContext.getBean(StateMachineWorker.class);
 
+        // set strategy for command execution in state machine
+        // ...
         // this should be generic, depending on a raft property
         // ...
         // ...
         StateMachineStrategy strategy = this.applicationContext.getBean(IndependentServer.class);
         worker.setStrategy(strategy);
+
+        // state machine subscribes events from a publisher of commits
+        CommitmentPublisher publisher = this.applicationContext.getBean(CommitmentPublisher.class);
+        publisher.subscribe(worker);
 
         this.taskExecutor.execute(worker);
 

--- a/servlet/src/main/java/com/springRaft/servlet/config/startup/StateMachine.java
+++ b/servlet/src/main/java/com/springRaft/servlet/config/startup/StateMachine.java
@@ -39,8 +39,13 @@ public class StateMachine implements ApplicationRunner {
     public void run(ApplicationArguments args) {
 
         StateMachineWorker worker = this.applicationContext.getBean(StateMachineWorker.class);
+
+        // this should be generic, depending on a raft property
+        // ...
+        // ...
         StateMachineStrategy strategy = this.applicationContext.getBean(IndependentServer.class);
         worker.setStrategy(strategy);
+
         this.taskExecutor.execute(worker);
 
     }

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Candidate.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Candidate.java
@@ -7,6 +7,7 @@ import com.springRaft.servlet.persistence.log.LogService;
 import com.springRaft.servlet.persistence.log.LogState;
 import com.springRaft.servlet.persistence.state.State;
 import com.springRaft.servlet.persistence.state.StateService;
+import com.springRaft.servlet.stateMachine.CommitmentPublisher;
 import com.springRaft.servlet.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,12 +42,13 @@ public class Candidate extends RaftStateContext implements RaftState {
             LogService logService,
             RaftProperties raftProperties,
             TransitionManager transitionManager,
-            OutboundManager outboundManager
+            OutboundManager outboundManager,
+            CommitmentPublisher commitmentPublisher
     ) {
         super(
                 applicationContext, consensusModule,
                 stateService, logService, raftProperties,
-                transitionManager, outboundManager
+                transitionManager, outboundManager, commitmentPublisher
         );
         this.scheduledFuture = null;
         this.requestVoteMessage = null;

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Follower.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Follower.java
@@ -5,6 +5,7 @@ import com.springRaft.servlet.communication.outbound.OutboundManager;
 import com.springRaft.servlet.config.RaftProperties;
 import com.springRaft.servlet.persistence.log.LogService;
 import com.springRaft.servlet.persistence.state.StateService;
+import com.springRaft.servlet.stateMachine.CommitmentPublisher;
 import com.springRaft.servlet.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,12 +37,13 @@ public class Follower extends RaftStateContext implements RaftState {
             LogService logService,
             RaftProperties raftProperties,
             TransitionManager transitionManager,
-            OutboundManager outboundManager
+            OutboundManager outboundManager,
+            CommitmentPublisher commitmentPublisher
     ) {
         super(
                 applicationContext, consensusModule,
                 stateService, logService, raftProperties,
-                transitionManager, outboundManager
+                transitionManager, outboundManager, commitmentPublisher
         );
         this.scheduledFuture = null;
         this.leaderId = raftProperties.AddressToString(raftProperties.getHost());

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Leader.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Leader.java
@@ -8,6 +8,7 @@ import com.springRaft.servlet.persistence.log.LogService;
 import com.springRaft.servlet.persistence.log.LogState;
 import com.springRaft.servlet.persistence.state.State;
 import com.springRaft.servlet.persistence.state.StateService;
+import com.springRaft.servlet.stateMachine.CommitmentPublisher;
 import com.springRaft.servlet.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,12 +46,13 @@ public class Leader extends RaftStateContext implements RaftState {
             LogService logService,
             RaftProperties raftProperties,
             TransitionManager transitionManager,
-            OutboundManager outboundManager
+            OutboundManager outboundManager,
+            CommitmentPublisher commitmentPublisher
     ) {
         super(
                 applicationContext, consensusModule,
                 stateService, logService, raftProperties,
-                transitionManager, outboundManager
+                transitionManager, outboundManager, commitmentPublisher
         );
 
         this.nextIndex = new HashMap<>();

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Leader.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Leader.java
@@ -88,6 +88,9 @@ public class Leader extends RaftStateContext implements RaftState {
                     this.matchIndex.put(from, nextIndex);
                     this.nextIndex.put(from, nextIndex + 1);
 
+                    // check if it is needed to set committed index
+                    this.setCommitIndex(from);
+
                 }
 
             } else {
@@ -343,6 +346,57 @@ public class Leader extends RaftStateContext implements RaftState {
                 entries, // entries
                 logState.getCommittedIndex() // leaderCommit
         );
+
+    }
+
+    /**
+     * Method that checks whether it is possible to commit an entry,
+     * and if so, commits it in the Log State as well as notifies the StateMachineWorker.
+     *
+     * @param from String that identifies the server that set a new matchIndex, to fetch its value.
+     * */
+    private void setCommitIndex(String from) {
+
+        LogState logState = this.logService.getState();
+        long N = this.matchIndex.get(from);
+        Entry entry = this.logService.getEntryByIndex(N);
+
+        if (
+                N > logState.getCommittedIndex() &&
+                entry.getTerm() == (long) this.stateService.getCurrentTerm() &&
+                this.majorityOfMatchIndexGreaterOrEqualThan(N)
+        ) {
+
+            logState.setCommittedIndex(N);
+            logState.setCommittedTerm(entry.getTerm());
+            this.logService.saveState(logState);
+
+            // notify state machine of a new commit
+            this.commitmentPublisher.newCommit();
+
+        }
+
+
+
+    }
+
+    /**
+     * Method that checks if an index is replicated in the majority of the servers
+     * in the cluster.
+     *
+     * @param N Long that represents the index to check.
+     *
+     * @return boolean that tells if the majority has or has not that index replicated.
+     * */
+    private boolean majorityOfMatchIndexGreaterOrEqualThan (long N) {
+
+        int count = 1; // 1 because of the leader that is not in matchIndex Map
+
+        for (long index : this.matchIndex.values())
+            if (index >= N)
+                count++;
+
+        return count >= this.raftProperties.getQuorum();
 
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/RaftStateContext.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/RaftStateContext.java
@@ -183,20 +183,13 @@ public abstract class RaftStateContext {
             LogState logState = this.logService.getState();
             if (appendEntries.getLeaderCommit() > logState.getCommittedIndex()) {
 
-                if (newEntry.getIndex() <= appendEntries.getLeaderCommit()) {
+                Entry entry = newEntry.getIndex() <= appendEntries.getLeaderCommit()
+                        ? newEntry
+                        : this.logService.getEntryByIndex(appendEntries.getLeaderCommit());
 
-                    logState.setCommittedIndex(newEntry.getIndex());
-                    logState.setCommittedTerm(newEntry.getTerm());
-                    this.logService.saveState(logState);
-
-                } else {
-
-                    long index = appendEntries.getLeaderCommit();
-                    Entry entry = this.logService.getEntryByIndex(index);
-                    logState.setCommittedIndex(entry.getIndex());
-                    logState.setCommittedTerm(entry.getTerm());
-
-                }
+                logState.setCommittedIndex(entry.getIndex());
+                logState.setCommittedTerm(entry.getTerm());
+                this.logService.saveState(logState);
 
             }
 

--- a/servlet/src/main/java/com/springRaft/servlet/stateMachine/CommitmentPublisher.java
+++ b/servlet/src/main/java/com/springRaft/servlet/stateMachine/CommitmentPublisher.java
@@ -1,0 +1,31 @@
+package com.springRaft.servlet.stateMachine;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Scope("singleton")
+public class CommitmentPublisher {
+
+    /* List of message subscribers */
+    private final List<CommitmentSubscriber> subscribers = new ArrayList<>();
+
+    /* --------------------------------------------------- */
+
+    public void subscribe(CommitmentSubscriber subscriber) {
+        this.subscribers.add(subscriber);
+    }
+
+    public void unsubscribe(CommitmentSubscriber subscriber) {
+        this.subscribers.remove(subscriber);
+    }
+
+    public void newCommit() {
+        for (CommitmentSubscriber subscriber : this.subscribers)
+            subscriber.newCommit();
+    }
+
+}

--- a/servlet/src/main/java/com/springRaft/servlet/stateMachine/CommitmentSubscriber.java
+++ b/servlet/src/main/java/com/springRaft/servlet/stateMachine/CommitmentSubscriber.java
@@ -1,0 +1,10 @@
+package com.springRaft.servlet.stateMachine;
+
+public interface CommitmentSubscriber {
+
+    /**
+     * Notification of new commit in Log State.
+     * */
+    void newCommit();
+
+}

--- a/servlet/src/main/java/com/springRaft/servlet/stateMachine/EmbeddedServer.java
+++ b/servlet/src/main/java/com/springRaft/servlet/stateMachine/EmbeddedServer.java
@@ -1,0 +1,15 @@
+package com.springRaft.servlet.stateMachine;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope("singleton")
+public class EmbeddedServer implements StateMachineStrategy {
+
+    @Override
+    public void apply(String command) {
+
+    }
+
+}

--- a/servlet/src/main/java/com/springRaft/servlet/stateMachine/IndependentServer.java
+++ b/servlet/src/main/java/com/springRaft/servlet/stateMachine/IndependentServer.java
@@ -24,7 +24,7 @@ public class IndependentServer implements StateMachineStrategy {
     @Override
     public void apply(String command) {
 
-        log.info("Applying: \"" + command + "\" to State Machine");
+        log.info("\n\nApplying: " + command + " to State Machine\n\n");
 
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/stateMachine/IndependentServer.java
+++ b/servlet/src/main/java/com/springRaft/servlet/stateMachine/IndependentServer.java
@@ -1,0 +1,15 @@
+package com.springRaft.servlet.stateMachine;
+
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope("singleton")
+public class IndependentServer implements StateMachineStrategy {
+
+    @Override
+    public void apply(String command) {
+
+    }
+
+}

--- a/servlet/src/main/java/com/springRaft/servlet/stateMachine/IndependentServer.java
+++ b/servlet/src/main/java/com/springRaft/servlet/stateMachine/IndependentServer.java
@@ -1,14 +1,30 @@
 package com.springRaft.servlet.stateMachine;
 
+import com.springRaft.servlet.communication.outbound.OutboundContext;
+import com.springRaft.servlet.worker.StateMachineWorker;
+import lombok.AllArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
 @Component
 @Scope("singleton")
+@AllArgsConstructor
 public class IndependentServer implements StateMachineStrategy {
+
+    /* Logger */
+    private static final Logger log = LoggerFactory.getLogger(StateMachineWorker.class);
+
+    /* Outbound context for communication to other servers */
+    private final OutboundContext outbound;
+
+    /* --------------------------------------------------- */
 
     @Override
     public void apply(String command) {
+
+        log.info("Applying: \"" + command + "\" to State Machine");
 
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/stateMachine/StateMachineStrategy.java
+++ b/servlet/src/main/java/com/springRaft/servlet/stateMachine/StateMachineStrategy.java
@@ -1,0 +1,12 @@
+package com.springRaft.servlet.stateMachine;
+
+public interface StateMachineStrategy {
+
+    /**
+     * Method for applying a command to the State Machine, depending on the strategy.
+     *
+     * @param command Command to apply to the State Machine.
+     * */
+    void apply(String command);
+
+}

--- a/servlet/src/main/java/com/springRaft/servlet/worker/PeerWorker.java
+++ b/servlet/src/main/java/com/springRaft/servlet/worker/PeerWorker.java
@@ -250,6 +250,9 @@ public class PeerWorker implements Runnable, MessageSubscriber {
                 // sleep for the remaining time, if any
                 this.waitWhileActiveAndNoRemainingMessages(start);
 
+                // go get the next heartbeat because the committed index may have changed
+                break;
+
             }
 
 

--- a/servlet/src/main/java/com/springRaft/servlet/worker/StateMachineWorker.java
+++ b/servlet/src/main/java/com/springRaft/servlet/worker/StateMachineWorker.java
@@ -1,0 +1,26 @@
+package com.springRaft.servlet.worker;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope("singleton")
+public class StateMachineWorker implements Runnable {
+
+    /* Logger */
+    private static final Logger log = LoggerFactory.getLogger(StateMachineWorker.class);
+
+    /* --------------------------------------------------- */
+
+    @Override
+    public void run() {
+
+        log.info("\n\nState Machine Worker working...\n\n");
+
+    }
+
+    /* --------------------------------------------------- */
+
+}

--- a/servlet/src/main/java/com/springRaft/servlet/worker/StateMachineWorker.java
+++ b/servlet/src/main/java/com/springRaft/servlet/worker/StateMachineWorker.java
@@ -1,7 +1,10 @@
 package com.springRaft.servlet.worker;
 
+import com.springRaft.servlet.persistence.log.LogService;
+import com.springRaft.servlet.persistence.log.LogState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
@@ -12,12 +15,29 @@ public class StateMachineWorker implements Runnable {
     /* Logger */
     private static final Logger log = LoggerFactory.getLogger(StateMachineWorker.class);
 
+    /* Service to access persisted log repository */
+    private final LogService logService;
+
+    private LogState logState;
+
+    /* --------------------------------------------------- */
+
+    @Autowired
+    public StateMachineWorker(LogService logService) {
+        this.logService = logService;
+        this.logState = this.logService.getState();
+    }
+
     /* --------------------------------------------------- */
 
     @Override
     public void run() {
 
         log.info("\n\nState Machine Worker working...\n\n");
+
+        // start working
+
+
 
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/worker/StateMachineWorker.java
+++ b/servlet/src/main/java/com/springRaft/servlet/worker/StateMachineWorker.java
@@ -110,9 +110,9 @@ public class StateMachineWorker implements Runnable, CommitmentSubscriber {
     private void applyCommitsToStateMachine() {
 
         LogState logState = this.logService.getState();
-        long entriesToCommit = logState.getCommittedIndex() - logState.getLastApplied();
+        long indexToStart = logState.getLastApplied() + 1;
 
-        for (long index = logState.getCommittedIndex() ; index < entriesToCommit ; index++) {
+        for (long index = indexToStart ; index <= logState.getCommittedIndex() ; index++) {
 
             // get command to apply
             String command = this.logService.getEntryByIndex(index).getCommand();


### PR DESCRIPTION
So far, this PR contains:

- Changes in ThreadPools (Renaming, documenting and sorting by name);
- Addition of a startup component that initializes StateMachineWorker;
- Simplification of an if-statement in RaftStateContext;
- Addition of StateMachineWorker thread that applies the commands in the log entries to the state machine;
- Addition of an Observer pattern (CommitmentPublisher and CommitmentSubscriber), for the followers and leader be notify the StateMachineWorker in a uniform way;
- Addition of set commitIndex in leader state when that index is replicated in the majority of servers in the cluster (quorum);
- Notification of the state machine worker when there are new committed entries;
- Addition of Strategy pattern (StateMachineStrategy, EmbeddedServer and IndependentServer) that define different ways of applying a command to the state machine;