### PR TITLE
Servlet - Client Requests Handling

### DIFF
--- a/servlet/src/main/java/com/springRaft/servlet/communication/inbound/RESTController.java
+++ b/servlet/src/main/java/com/springRaft/servlet/communication/inbound/RESTController.java
@@ -79,7 +79,7 @@ public class RESTController implements InboundCommunication {
             consumes = "application/json",
             produces = "application/json"
     )
-    public ResponseEntity<Boolean> clientRequestEndpoint(@RequestBody String command) throws URISyntaxException {
+    public ResponseEntity<?> clientRequestEndpoint(@RequestBody String command) throws URISyntaxException {
 
         RequestReply reply = this.clientRequest(command);
 
@@ -92,7 +92,7 @@ public class RESTController implements InboundCommunication {
 
         } else {
 
-            return new ResponseEntity<>(reply.getSuccess(), HttpStatus.CREATED);
+            return new ResponseEntity<>(reply, HttpStatus.CREATED);
 
         }
 

--- a/servlet/src/main/java/com/springRaft/servlet/communication/inbound/RESTController.java
+++ b/servlet/src/main/java/com/springRaft/servlet/communication/inbound/RESTController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Map;
 
 @RestController
 @RequestMapping("raft")
@@ -92,7 +93,9 @@ public class RESTController implements InboundCommunication {
 
         } else {
 
-            return new ResponseEntity<>(reply, HttpStatus.CREATED);
+            Map<String,?> replyEntity = Map.of("success",reply.getSuccess(), "response", reply.getResponse());
+
+            return new ResponseEntity<>(replyEntity, HttpStatus.CREATED);
 
         }
 

--- a/servlet/src/main/java/com/springRaft/servlet/communication/message/RequestReply.java
+++ b/servlet/src/main/java/com/springRaft/servlet/communication/message/RequestReply.java
@@ -6,20 +6,44 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Scope("prototype")
-@AllArgsConstructor
-@NoArgsConstructor
 @Getter
 @Setter
 @ToString
 public class RequestReply implements Message {
 
-    /* Success of the request --- PROBABLY IT SHOULD BE THE RESULT OF THE OPERATION */
+    /* Success of the request */
     private Boolean success;
+
+    /* Result of applying a command to the state machine */
+    private Object response;
 
     /* If this server is not the leader we have to redirect the request */
     private Boolean redirect;
 
     /* Where to redirect the request */
     private String redirectTo;
+
+    /* --------------------------------------------------- */
+
+    public RequestReply() {
+        this.success = false;
+        this.response = null;
+        this.redirect = false;
+        this.redirectTo = null;
+    }
+
+    public RequestReply(String redirectTo) {
+        this.success = false;
+        this.response = null;
+        this.redirect = true;
+        this.redirectTo = redirectTo;
+    }
+
+    public RequestReply(Object response) {
+        this.success = true;
+        this.response = response;
+        this.redirect = false;
+        this.redirectTo = null;
+    }
 
 }

--- a/servlet/src/main/java/com/springRaft/servlet/communication/message/RequestReply.java
+++ b/servlet/src/main/java/com/springRaft/servlet/communication/message/RequestReply.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Scope("prototype")
+@AllArgsConstructor
+@NoArgsConstructor
 @Getter
 @Setter
 @ToString
@@ -22,28 +24,5 @@ public class RequestReply implements Message {
 
     /* Where to redirect the request */
     private String redirectTo;
-
-    /* --------------------------------------------------- */
-
-    public RequestReply() {
-        this.success = false;
-        this.response = null;
-        this.redirect = false;
-        this.redirectTo = null;
-    }
-
-    public RequestReply(String redirectTo) {
-        this.success = false;
-        this.response = null;
-        this.redirect = true;
-        this.redirectTo = redirectTo;
-    }
-
-    public RequestReply(Object response) {
-        this.success = true;
-        this.response = response;
-        this.redirect = false;
-        this.redirectTo = null;
-    }
 
 }

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Candidate.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Candidate.java
@@ -8,6 +8,7 @@ import com.springRaft.servlet.persistence.log.LogState;
 import com.springRaft.servlet.persistence.state.State;
 import com.springRaft.servlet.persistence.state.StateService;
 import com.springRaft.servlet.stateMachine.CommitmentPublisher;
+import com.springRaft.servlet.stateMachine.WaitingRequests;
 import com.springRaft.servlet.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,12 +44,14 @@ public class Candidate extends RaftStateContext implements RaftState {
             RaftProperties raftProperties,
             TransitionManager transitionManager,
             OutboundManager outboundManager,
-            CommitmentPublisher commitmentPublisher
+            CommitmentPublisher commitmentPublisher,
+            WaitingRequests waitingRequests
     ) {
         super(
                 applicationContext, consensusModule,
                 stateService, logService, raftProperties,
-                transitionManager, outboundManager, commitmentPublisher
+                transitionManager, outboundManager,
+                commitmentPublisher, waitingRequests
         );
         this.scheduledFuture = null;
         this.requestVoteMessage = null;

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Candidate.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Candidate.java
@@ -201,7 +201,7 @@ public class Candidate extends RaftStateContext implements RaftState {
         // When in candidate state, there is nowhere to redirect the request or a leader to
         // handle them.
 
-        return this.applicationContext.getBean(RequestReply.class);
+        return this.applicationContext.getBean(RequestReply.class, false, new Object(), false, "");
 
         // probably we should store the requests, and redirect them when we became follower
         // or handle them when became leader

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Candidate.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Candidate.java
@@ -201,7 +201,7 @@ public class Candidate extends RaftStateContext implements RaftState {
         // When in candidate state, there is nowhere to redirect the request or a leader to
         // handle them.
 
-        return this.applicationContext.getBean(RequestReply.class, false, false, null);
+        return this.applicationContext.getBean(RequestReply.class);
 
         // probably we should store the requests, and redirect them when we became follower
         // or handle them when became leader

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/ConsensusModule.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/ConsensusModule.java
@@ -70,7 +70,6 @@ public class ConsensusModule implements RaftState {
     }
 
     @Override
-    @Synchronized
     public RequestReply clientRequest(String command) {
         return this.current.clientRequest(command);
     }

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Follower.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Follower.java
@@ -161,7 +161,7 @@ public class Follower extends RaftStateContext implements RaftState {
     public RequestReply clientRequest(String command) {
 
         // When in follower state, we need to redirect the request to the leader
-        return this.applicationContext.getBean(RequestReply.class, false, true, this.leaderId);
+        return this.applicationContext.getBean(RequestReply.class, this.leaderId);
 
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Follower.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Follower.java
@@ -6,6 +6,7 @@ import com.springRaft.servlet.config.RaftProperties;
 import com.springRaft.servlet.persistence.log.LogService;
 import com.springRaft.servlet.persistence.state.StateService;
 import com.springRaft.servlet.stateMachine.CommitmentPublisher;
+import com.springRaft.servlet.stateMachine.WaitingRequests;
 import com.springRaft.servlet.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,12 +39,14 @@ public class Follower extends RaftStateContext implements RaftState {
             RaftProperties raftProperties,
             TransitionManager transitionManager,
             OutboundManager outboundManager,
-            CommitmentPublisher commitmentPublisher
+            CommitmentPublisher commitmentPublisher,
+            WaitingRequests waitingRequests
     ) {
         super(
                 applicationContext, consensusModule,
                 stateService, logService, raftProperties,
-                transitionManager, outboundManager, commitmentPublisher
+                transitionManager, outboundManager,
+                commitmentPublisher, waitingRequests
         );
         this.scheduledFuture = null;
         this.leaderId = raftProperties.AddressToString(raftProperties.getHost());

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Follower.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Follower.java
@@ -161,7 +161,7 @@ public class Follower extends RaftStateContext implements RaftState {
     public RequestReply clientRequest(String command) {
 
         // When in follower state, we need to redirect the request to the leader
-        return this.applicationContext.getBean(RequestReply.class, this.leaderId);
+        return this.applicationContext.getBean(RequestReply.class, false, new Object(), true, this.leaderId);
 
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Leader.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Leader.java
@@ -233,8 +233,8 @@ public class Leader extends RaftStateContext implements RaftState {
 
 
         return response != null
-                ? this.applicationContext.getBean(RequestReply.class, true, false, null)
-                : this.applicationContext.getBean(RequestReply.class, false, false, null);
+                ? this.applicationContext.getBean(RequestReply.class, response)
+                : this.applicationContext.getBean(RequestReply.class);
 
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Leader.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Leader.java
@@ -9,6 +9,8 @@ import com.springRaft.servlet.persistence.log.LogState;
 import com.springRaft.servlet.persistence.state.State;
 import com.springRaft.servlet.persistence.state.StateService;
 import com.springRaft.servlet.stateMachine.CommitmentPublisher;
+import com.springRaft.servlet.stateMachine.WaitingRequests;
+import com.springRaft.servlet.stateMachine.WaitingRoom;
 import com.springRaft.servlet.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,12 +49,14 @@ public class Leader extends RaftStateContext implements RaftState {
             RaftProperties raftProperties,
             TransitionManager transitionManager,
             OutboundManager outboundManager,
-            CommitmentPublisher commitmentPublisher
+            CommitmentPublisher commitmentPublisher,
+            WaitingRequests waitingRequests
     ) {
         super(
                 applicationContext, consensusModule,
                 stateService, logService, raftProperties,
-                transitionManager, outboundManager, commitmentPublisher
+                transitionManager, outboundManager,
+                commitmentPublisher, waitingRequests
         );
 
         this.nextIndex = new HashMap<>();
@@ -226,6 +230,13 @@ public class Leader extends RaftStateContext implements RaftState {
         // ...
         // ...
         // ...
+
+        Object response = this.waitingRequests
+                .insertWaitingRequest(entry.getIndex())
+                .getResponse();
+
+
+
         return this.applicationContext.getBean(RequestReply.class, true, false, null);
 
     }

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Leader.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Leader.java
@@ -10,7 +10,6 @@ import com.springRaft.servlet.persistence.state.State;
 import com.springRaft.servlet.persistence.state.StateService;
 import com.springRaft.servlet.stateMachine.CommitmentPublisher;
 import com.springRaft.servlet.stateMachine.WaitingRequests;
-import com.springRaft.servlet.stateMachine.WaitingRoom;
 import com.springRaft.servlet.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -221,7 +220,7 @@ public class Leader extends RaftStateContext implements RaftState {
 
         // appends the command to its log as a new entry
         Entry entry = this.logService.insertEntry(new Entry(this.stateService.getCurrentTerm(), command));
-        log.info("NEW ENTRY IN LOG: " + entry.toString());
+        log.info("\n\nNEW ENTRY IN LOG: " + entry.toString());
 
         // notify PeerWorkers that a new request is available
         this.outboundManager.newMessage();
@@ -231,10 +230,9 @@ public class Leader extends RaftStateContext implements RaftState {
                 .insertWaitingRequest(entry.getIndex())
                 .getResponse();
 
-
         return response != null
-                ? this.applicationContext.getBean(RequestReply.class, response)
-                : this.applicationContext.getBean(RequestReply.class);
+                ? this.applicationContext.getBean(RequestReply.class, true, response, false, "")
+                : this.applicationContext.getBean(RequestReply.class, false, new Object(), false, "");
 
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Leader.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Leader.java
@@ -220,7 +220,6 @@ public class Leader extends RaftStateContext implements RaftState {
 
         // appends the command to its log as a new entry
         Entry entry = this.logService.insertEntry(new Entry(this.stateService.getCurrentTerm(), command));
-        log.info("\n\nNEW ENTRY IN LOG: " + entry.toString());
 
         // notify PeerWorkers that a new request is available
         this.outboundManager.newMessage();

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Leader.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Leader.java
@@ -226,18 +226,15 @@ public class Leader extends RaftStateContext implements RaftState {
         // notify PeerWorkers that a new request is available
         this.outboundManager.newMessage();
 
-        // temporary response
-        // ...
-        // ...
-        // ...
-
+        // get response after state machine applied it
         Object response = this.waitingRequests
                 .insertWaitingRequest(entry.getIndex())
                 .getResponse();
 
 
-
-        return this.applicationContext.getBean(RequestReply.class, true, false, null);
+        return response != null
+                ? this.applicationContext.getBean(RequestReply.class, true, false, null)
+                : this.applicationContext.getBean(RequestReply.class, false, false, null);
 
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/RaftStateContext.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/RaftStateContext.java
@@ -11,6 +11,7 @@ import com.springRaft.servlet.persistence.log.LogService;
 import com.springRaft.servlet.persistence.log.LogState;
 import com.springRaft.servlet.persistence.state.StateService;
 import com.springRaft.servlet.stateMachine.CommitmentPublisher;
+import com.springRaft.servlet.stateMachine.WaitingRequests;
 import lombok.AllArgsConstructor;
 import org.springframework.context.ApplicationContext;
 
@@ -40,6 +41,9 @@ public abstract class RaftStateContext {
 
     /* Publisher of new commitments to State Machine */
     protected final CommitmentPublisher commitmentPublisher;
+
+    /* Map that contains the clients waiting requests */
+    protected final WaitingRequests waitingRequests;
 
     /* --------------------------------------------------- */
 

--- a/servlet/src/main/java/com/springRaft/servlet/persistence/log/LogService.java
+++ b/servlet/src/main/java/com/springRaft/servlet/persistence/log/LogService.java
@@ -1,6 +1,7 @@
 package com.springRaft.servlet.persistence.log;
 
 import lombok.AllArgsConstructor;
+import lombok.Synchronized;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -64,6 +65,7 @@ public class LogService {
     /**
      * TODO
      * */
+    @Synchronized
     public Entry insertEntry(Entry entry) {
 
         Long lastIndex = this.getLastEntryIndex();

--- a/servlet/src/main/java/com/springRaft/servlet/stateMachine/EmbeddedServer.java
+++ b/servlet/src/main/java/com/springRaft/servlet/stateMachine/EmbeddedServer.java
@@ -8,7 +8,9 @@ import org.springframework.stereotype.Component;
 public class EmbeddedServer implements StateMachineStrategy {
 
     @Override
-    public void apply(String command) {
+    public Object apply(String command) {
+
+        return "Applied: " + command + ", to State Machine";
 
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/stateMachine/IndependentServer.java
+++ b/servlet/src/main/java/com/springRaft/servlet/stateMachine/IndependentServer.java
@@ -22,9 +22,11 @@ public class IndependentServer implements StateMachineStrategy {
     /* --------------------------------------------------- */
 
     @Override
-    public void apply(String command) {
+    public Object apply(String command) {
 
         log.info("\n\nApplying: " + command + " to State Machine\n\n");
+
+        return "Applied: " + command + ", to State Machine";
 
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/stateMachine/StateMachineStrategy.java
+++ b/servlet/src/main/java/com/springRaft/servlet/stateMachine/StateMachineStrategy.java
@@ -6,7 +6,9 @@ public interface StateMachineStrategy {
      * Method for applying a command to the State Machine, depending on the strategy.
      *
      * @param command Command to apply to the State Machine.
+     *
+     * @return Object that represents the response.
      * */
-    void apply(String command);
+    Object apply(String command);
 
 }

--- a/servlet/src/main/java/com/springRaft/servlet/stateMachine/WaitingRequests.java
+++ b/servlet/src/main/java/com/springRaft/servlet/stateMachine/WaitingRequests.java
@@ -58,4 +58,21 @@ public class WaitingRequests {
 
     }
 
+    /**
+     * Method that puts a response in a waiting room, and removes it from the map,
+     * because the client request is already responded.
+     *
+     * @param index Entry's index that is the key in the map.
+     * @param response Object that represents the response to the client request.
+     * */
+    @Synchronized
+    public void putResponse(Long index, Object response) {
+
+        WaitingRoom room = this.clientRequests.remove(index);
+
+        if (room != null)
+            room.putResponse(response);
+
+    }
+
 }

--- a/servlet/src/main/java/com/springRaft/servlet/stateMachine/WaitingRequests.java
+++ b/servlet/src/main/java/com/springRaft/servlet/stateMachine/WaitingRequests.java
@@ -1,0 +1,61 @@
+package com.springRaft.servlet.stateMachine;
+
+import lombok.Synchronized;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@Scope("singleton")
+public class WaitingRequests {
+
+    /* Application Context for getting beans */
+    private final ApplicationContext applicationContext;
+
+    /* Map that holds indexes and waiting rooms */
+    private final Map<Long,WaitingRoom> clientRequests;
+
+    /* --------------------------------------------------- */
+
+    @Autowired
+    public WaitingRequests (ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+        this.clientRequests = new HashMap<>();
+    }
+
+    /* --------------------------------------------------- */
+
+    /**
+     * Method that inserts a new client request and its waiting room in the clientRequests Map.
+     *
+     * @param index Key to put in the Map.
+     *
+     * @return WaitingRoom which is the room for this request.
+     * */
+    @Synchronized
+    public WaitingRoom insertWaitingRequest(Long index) {
+
+        // getting a room
+        WaitingRoom room = this.applicationContext.getBean(WaitingRoom.class);
+
+        WaitingRoom previousRoom = this.clientRequests.putIfAbsent(index, room);
+
+        if (previousRoom != null) {
+
+            // send a null response to the previous
+            previousRoom.putResponse();
+
+            // put the new room
+            this.clientRequests.put(index, room);
+
+        }
+
+        return room;
+
+    }
+
+}

--- a/servlet/src/main/java/com/springRaft/servlet/stateMachine/WaitingRoom.java
+++ b/servlet/src/main/java/com/springRaft/servlet/stateMachine/WaitingRoom.java
@@ -1,0 +1,87 @@
+package com.springRaft.servlet.stateMachine;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Component
+@Scope("prototype")
+public class WaitingRoom {
+
+    /* Logger */
+    private static final Logger log = LoggerFactory.getLogger(WaitingRoom.class);
+
+    /* Mutex for some operations */
+    private final Lock l = new ReentrantLock();
+
+    /* Condition where a thread can wait for state to changes */
+    private final Condition cond = l.newCondition();
+
+    /* Response to deliver to client */
+    private Object response = null;
+
+    /* Boolean that dictates whether this waiting room has a response */
+    private boolean hasResponse = false;
+
+    /* --------------------------------------------------- */
+
+    /**
+     * Method that blocks a thread, and waits for a response.
+     *
+     * @return Object that is the generic way to respond something.
+     * */
+    public Object getResponse(){
+
+        l.lock();
+        try{
+
+            while(response == null && !hasResponse)
+                cond.await();
+
+        } catch (InterruptedException e) {
+
+            log.error("Exception while awaiting on getResponse");
+
+        } finally {
+            l.unlock();
+        }
+
+        return response;
+
+    }
+
+    /**
+     * Method for putting a null response.
+     * */
+    void putResponse() {
+
+        this.putResponse(null);
+
+    }
+
+    /**
+     * Method for put a response in this waiting room and notify the thread waiting for this response.
+     *
+     * @param response Object to respond.
+     * */
+    void putResponse(Object response){
+
+        l.lock();
+        try {
+
+            this.response = response;
+            this.hasResponse = true;
+            cond.signal();
+
+        } finally {
+            l.unlock();
+        }
+
+    }
+
+}


### PR DESCRIPTION
This PR adds:

- Response in RequestReply;
- Deletion of `@Synchronized` in clientRequest method because this method has blocking operations, which blocks all the algorithm;
- Client requests are handled with a WaitingRequests structure and a WaitingRoom where request threads block until a response is available. The StateMachineWorker is the thread that puts the response and unlocks request threads.

Resolves: #41 