### PR TITLE
Servlet - Remove Redirection

### DIFF
--- a/servlet/src/main/java/com/springRaft/servlet/communication/inbound/IndependentController.java
+++ b/servlet/src/main/java/com/springRaft/servlet/communication/inbound/IndependentController.java
@@ -1,14 +1,18 @@
 package com.springRaft.servlet.communication.inbound;
 
+import com.springRaft.servlet.communication.outbound.OutboundContext;
+import com.springRaft.servlet.config.RaftProperties;
 import lombok.AllArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpServletRequest;
-import java.net.URISyntaxException;
+import java.util.Objects;
 
 @RestController
 @ConditionalOnProperty(name = "raft.state-machine-strategy", havingValue = "INDEPENDENT")
@@ -18,17 +22,43 @@ public class IndependentController {
     /* Main controller that communicates with consensus module */
     private final RaftController raftController;
 
+    /* Raft properties that need to be accessed */
+    private final RaftProperties raftProperties;
+
+    /* Outbound context for communication to other servers */
+    protected final OutboundContext outbound;
+
     /* --------------------------------------------------- */
 
     /**
      * TODO
      * */
     @RequestMapping(value = "/**/{[^\\.]*}")
-    public ResponseEntity<?> clientRequestEndpoint(@RequestBody(required = false) String body, HttpServletRequest request) throws URISyntaxException {
+    public ResponseEntity<?> clientRequestEndpoint(@RequestBody(required = false) String body, HttpServletRequest request) {
 
         String command = request.getMethod() + ";;;" + request.getRequestURI() + ";;;" + body;
 
-        return this.raftController.clientRequestHandling(request, command);
+        try {
+
+            ResponseEntity<?> response = this.raftController.clientRequestHandling(command);
+
+            if ( response.getStatusCode() == HttpStatus.TEMPORARY_REDIRECT) {
+
+                String location = Objects.requireNonNull(response.getHeaders().get("raft-leader")).get(0);
+
+                response = (ResponseEntity<?>) this.outbound.request(command, location);
+
+            }
+
+            return response;
+
+        } catch (Exception e) {
+
+            HttpHeaders httpHeaders = new HttpHeaders();
+            httpHeaders.set(HttpHeaders.RETRY_AFTER, Long.toString(this.raftProperties.getHeartbeat().toMillis() / 1000));
+            return new ResponseEntity<>(httpHeaders, HttpStatus.SERVICE_UNAVAILABLE);
+
+        }
 
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/communication/inbound/RaftController.java
+++ b/servlet/src/main/java/com/springRaft/servlet/communication/inbound/RaftController.java
@@ -1,8 +1,6 @@
 package com.springRaft.servlet.communication.inbound;
 
 import com.springRaft.servlet.communication.message.*;
-import com.springRaft.servlet.communication.outbound.OutboundContext;
-import com.springRaft.servlet.config.RaftProperties;
 import com.springRaft.servlet.consensusModule.ConsensusModule;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -13,8 +11,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.servlet.http.HttpServletRequest;
-
 @RestController
 @RequestMapping("raft")
 @AllArgsConstructor
@@ -22,12 +18,6 @@ public class RaftController implements InboundCommunication {
 
     /* Module that has the consensus functions to invoke */
     private final ConsensusModule consensusModule;
-
-    /* Raft properties that need to be accessed */
-    private final RaftProperties raftProperties;
-
-    /* Outbound context for communication to other servers */
-    protected final OutboundContext outbound;
 
     /* --------------------------------------------------- */
 
@@ -86,34 +76,20 @@ public class RaftController implements InboundCommunication {
 
     /* --------------------------------------------------- */
 
-    public ResponseEntity<?> clientRequestHandling(HttpServletRequest request, String command) {
+    public ResponseEntity<?> clientRequestHandling(String command) {
 
         RequestReply reply = this.clientRequest(command);
 
-        try {
-
-            if (reply.getRedirect()) {
-
-                /*
-                URI leaderURL = new URI("http://" + reply.getRedirectTo() + request.getRequestURI());
-                HttpHeaders httpHeaders = new HttpHeaders();
-                httpHeaders.setLocation(leaderURL);
-                return new ResponseEntity<>(httpHeaders, HttpStatus.TEMPORARY_REDIRECT);
-                */
-
-                return (ResponseEntity<?>) this.outbound.request(command, reply.getRedirectTo());
-
-            } else {
-
-                return (ResponseEntity<?>) reply.getResponse();
-
-            }
-
-        } catch (Exception e) {
+        if (reply.getRedirect()) {
 
             HttpHeaders httpHeaders = new HttpHeaders();
-            httpHeaders.set(HttpHeaders.RETRY_AFTER, Long.toString(this.raftProperties.getHeartbeat().toMillis() / 1000));
-            return new ResponseEntity<>(httpHeaders, HttpStatus.SERVICE_UNAVAILABLE);
+            httpHeaders.set("raft-leader", reply.getRedirectTo());
+
+            return new ResponseEntity<>(httpHeaders, HttpStatus.TEMPORARY_REDIRECT);
+
+        } else {
+
+            return (ResponseEntity<?>) reply.getResponse();
 
         }
 

--- a/servlet/src/main/java/com/springRaft/servlet/communication/outbound/OutboundContext.java
+++ b/servlet/src/main/java/com/springRaft/servlet/communication/outbound/OutboundContext.java
@@ -39,8 +39,8 @@ public class OutboundContext implements OutboundStrategy {
     }
 
     @Override
-    public Object request(String command) throws InterruptedException, ExecutionException, TimeoutException, URISyntaxException {
-        return this.communicationStrategy.request(command);
+    public Object request(String command, String location) throws InterruptedException, ExecutionException, TimeoutException, URISyntaxException {
+        return this.communicationStrategy.request(command, location);
     }
 
 }

--- a/servlet/src/main/java/com/springRaft/servlet/communication/outbound/OutboundContext.java
+++ b/servlet/src/main/java/com/springRaft/servlet/communication/outbound/OutboundContext.java
@@ -39,7 +39,7 @@ public class OutboundContext implements OutboundStrategy {
     }
 
     @Override
-    public Object request(String command, String location) throws InterruptedException, ExecutionException, TimeoutException, URISyntaxException {
+    public Object request(String command, String location) throws InterruptedException, ExecutionException, URISyntaxException {
         return this.communicationStrategy.request(command, location);
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/communication/outbound/OutboundStrategy.java
+++ b/servlet/src/main/java/com/springRaft/servlet/communication/outbound/OutboundStrategy.java
@@ -24,6 +24,6 @@ public interface OutboundStrategy {
     /**
      * TODO
      * */
-    Object request(String command, String location) throws InterruptedException, ExecutionException, TimeoutException, URISyntaxException;
+    Object request(String command, String location) throws InterruptedException, ExecutionException, URISyntaxException;
 
 }

--- a/servlet/src/main/java/com/springRaft/servlet/communication/outbound/OutboundStrategy.java
+++ b/servlet/src/main/java/com/springRaft/servlet/communication/outbound/OutboundStrategy.java
@@ -10,7 +10,20 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 public interface OutboundStrategy {
+
+    /**
+     * TODO
+     * */
     AppendEntriesReply appendEntries(String to, AppendEntries message) throws InterruptedException, ExecutionException, TimeoutException;
+
+    /**
+     * TODO
+     * */
     RequestVoteReply requestVote(String to, RequestVote message) throws InterruptedException, ExecutionException, TimeoutException;
-    Object request(String command) throws InterruptedException, ExecutionException, TimeoutException, URISyntaxException;
+
+    /**
+     * TODO
+     * */
+    Object request(String command, String location) throws InterruptedException, ExecutionException, TimeoutException, URISyntaxException;
+
 }

--- a/servlet/src/main/java/com/springRaft/servlet/communication/outbound/REST.java
+++ b/servlet/src/main/java/com/springRaft/servlet/communication/outbound/REST.java
@@ -62,7 +62,7 @@ public class REST implements OutboundStrategy {
     }
 
     @Override
-    public Object request(String command, String location) throws InterruptedException, ExecutionException, TimeoutException, URISyntaxException {
+    public Object request(String command, String location) throws URISyntaxException, ExecutionException, InterruptedException {
 
         String[] tokens = command.split(";;;");
         HttpMethod HTTPMethod = HttpMethod.valueOf(tokens[0]);

--- a/servlet/src/main/java/com/springRaft/servlet/stateMachine/SMStrategyContext.java
+++ b/servlet/src/main/java/com/springRaft/servlet/stateMachine/SMStrategyContext.java
@@ -8,7 +8,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 @AllArgsConstructor
 public class SMStrategyContext {
@@ -44,11 +43,6 @@ public class SMStrategyContext {
                 // sleep for the remaining time, if any
                 // based on heartbeat
                 this.sleepForSomeTime(start);
-
-            } catch (TimeoutException e) {
-
-                // If the communication exceeded heartbeat timout
-                log.warn("Communication to Application Server exceeded heartbeat timeout!!");
 
             } catch (Exception e) {
 

--- a/servlet/src/main/java/com/springRaft/servlet/stateMachine/SMStrategyContext.java
+++ b/servlet/src/main/java/com/springRaft/servlet/stateMachine/SMStrategyContext.java
@@ -34,7 +34,7 @@ public class SMStrategyContext {
 
             try {
 
-                reply = this.outbound.request(command);
+                reply = this.outbound.request(command, this.raftProperties.getApplicationServer());
 
             } catch (ExecutionException e) {
                 // If target server is not alive


### PR DESCRIPTION
Instead of redirecting a request with a 307 code, a follower server acts as a client and invoke the request on the leader.
This behavior is the same as the etcd.