### PR TITLE
Reactive - Candidate-Candidate Transition

### DIFF
--- a/reactive/src/main/java/com/springRaft/reactive/config/ConstructorBeans.java
+++ b/reactive/src/main/java/com/springRaft/reactive/config/ConstructorBeans.java
@@ -14,7 +14,7 @@ public class ConstructorBeans {
      * */
     @Bean(name = "InitialState")
     public State newState() {
-        return new State((long) 1,(long) 1,null);
+        return new State((long) 1,(long) 1,null, true);
     }
 
 }

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/Candidate.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/Candidate.java
@@ -1,6 +1,7 @@
 package com.springRaft.reactive.consensusModule;
 
 import com.springRaft.reactive.config.RaftProperties;
+import com.springRaft.reactive.persistence.state.StateService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
@@ -23,10 +24,11 @@ public class Candidate extends RaftStateContext implements RaftState {
     public Candidate(
             ApplicationContext applicationContext,
             ConsensusModule consensusModule,
+            StateService stateService,
             RaftProperties raftProperties,
             TransitionManager transitionManager
     ) {
-        super(applicationContext, consensusModule, raftProperties, transitionManager);
+        super(applicationContext, consensusModule, stateService, raftProperties, transitionManager);
         this.scheduledTransition = null;
     }
 
@@ -37,8 +39,13 @@ public class Candidate extends RaftStateContext implements RaftState {
 
         log.info("CANDIDATE");
 
-        this.setTimeout();
+        // persist new state
+        this.stateService.newCandidateState()
+                .doOnSuccess(state -> log.info(state.toString()))
+                .subscribe();
 
+        // set a candidate timeout
+        this.setTimeout();
     }
 
     /* --------------------------------------------------- */

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/Follower.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/Follower.java
@@ -1,6 +1,7 @@
 package com.springRaft.reactive.consensusModule;
 
 import com.springRaft.reactive.config.RaftProperties;
+import com.springRaft.reactive.persistence.state.StateService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
@@ -26,10 +27,11 @@ public class Follower extends RaftStateContext implements RaftState {
     public Follower(
             ApplicationContext applicationContext,
             ConsensusModule consensusModule,
+            StateService stateService,
             RaftProperties raftProperties,
             TransitionManager transitionManager
     ) {
-        super(applicationContext, consensusModule, raftProperties, transitionManager);
+        super(applicationContext, consensusModule, stateService, raftProperties, transitionManager);
         this.scheduledTransition = null;
         this.leaderId = raftProperties.getHost();
     }

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/RaftStateContext.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/RaftStateContext.java
@@ -1,6 +1,7 @@
 package com.springRaft.reactive.consensusModule;
 
 import com.springRaft.reactive.config.RaftProperties;
+import com.springRaft.reactive.persistence.state.StateService;
 import lombok.AllArgsConstructor;
 import org.springframework.context.ApplicationContext;
 
@@ -14,7 +15,7 @@ public abstract class RaftStateContext {
     protected final ConsensusModule consensusModule;
 
     /* Service to access persisted state repository */
-    // ...
+    protected final StateService stateService;
 
     /* Service to access persisted log repository */
     // ...

--- a/reactive/src/main/java/com/springRaft/reactive/persistence/state/State.java
+++ b/reactive/src/main/java/com/springRaft/reactive/persistence/state/State.java
@@ -2,6 +2,7 @@ package com.springRaft.reactive.persistence.state;
 
 import lombok.*;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Transient;
 import org.springframework.data.domain.Persistable;
 
 @Data
@@ -22,10 +23,14 @@ public class State implements Persistable<Long> {
     /* Who the vote was for in the current term */
     private String votedFor;
 
+    /* Transient flag that states ith the object is new or already in database */
+    @Transient
+    private boolean isNew;
+
     /* --------------------------------------------------- */
 
     @Override
     public boolean isNew() {
-        return id != null;
+        return isNew;
     }
 }


### PR DESCRIPTION
This PR adds:

- Transient field in State model in order to update an object instead of trying to create a new one;
- Transits correctly to a new candidate state, persisting the new state in the database;
