### PR TITLE
Reactive - Leader's Authority

### DIFF
--- a/reactive/src/main/java/com/springRaft/reactive/communication/inbound/InboundCommunication.java
+++ b/reactive/src/main/java/com/springRaft/reactive/communication/inbound/InboundCommunication.java
@@ -1,9 +1,30 @@
 package com.springRaft.reactive.communication.inbound;
 
+import com.springRaft.reactive.communication.message.AppendEntries;
+import com.springRaft.reactive.communication.message.AppendEntriesReply;
 import com.springRaft.reactive.communication.message.RequestVote;
 import com.springRaft.reactive.communication.message.RequestVoteReply;
 import reactor.core.publisher.Mono;
 
 public interface InboundCommunication {
+
+    /**
+     * Abstract method for the inbound strategies to implement it, so they can handle the reception
+     * of the appendEntriesRPC.
+     *
+     * @param appendEntries Message received in AppendEntriesRPC.
+     *
+     * @return Mono<AppendEntriesReply> Reply to send to the server which invoke the communication.
+     * */
+    Mono<AppendEntriesReply> appendEntries(AppendEntries appendEntries);
+
+    /**
+     * Abstract method for the inbound strategies to implement it, so they can handle the reception
+     * of the requestVoteRPC.
+     *
+     * @param requestVote Message received in requestVoteRPC.
+     *
+     * @return Mono<RequestVoteReply> Reply to send to the server which invoke the communication.
+     * */
     Mono<RequestVoteReply> requestVote(RequestVote requestVote);
 }

--- a/reactive/src/main/java/com/springRaft/reactive/communication/inbound/RaftController.java
+++ b/reactive/src/main/java/com/springRaft/reactive/communication/inbound/RaftController.java
@@ -29,7 +29,31 @@ public class RaftController implements InboundCommunication {
     /* --------------------------------------------------- */
 
     /**
-     * TODO
+     * Method that handles all the POST calls on "/raft/appendEntries" endpoint.
+     *
+     * @param appendEntries Object that represents an appendEntries message.
+     *
+     * @return Mono<ResponseEntity<AppendEntries>> A response entity which includes the reply
+     * to the appendEntries communication.
+     * */
+    @RequestMapping(
+            value = "/appendEntries",
+            method = RequestMethod.POST,
+            consumes = "application/json",
+            produces = "application/json"
+    )
+    public Mono<ResponseEntity<AppendEntriesReply>> appendEntriesEndpoint(@RequestBody AppendEntries appendEntries) {
+        return this.appendEntries(appendEntries)
+                .map(ResponseEntity::ok);
+    }
+
+    /**
+     * Method that handles all the POST calls on "/raft/requestVote" endpoint.
+     *
+     * @param requestVote Object that represents a requestVote message.
+     *
+     * @return Mono<ResponseEntity<RequestVoteReply>> A response entity which includes the reply
+     * to the requestVote communication.
      * */
     @RequestMapping(
             value = "/requestVote",

--- a/reactive/src/main/java/com/springRaft/reactive/communication/inbound/RaftController.java
+++ b/reactive/src/main/java/com/springRaft/reactive/communication/inbound/RaftController.java
@@ -44,6 +44,7 @@ public class RaftController implements InboundCommunication {
     )
     public Mono<ResponseEntity<AppendEntriesReply>> appendEntriesEndpoint(@RequestBody AppendEntries appendEntries) {
         return this.appendEntries(appendEntries)
+                .doOnNext(reply -> log.info("\nAPPEND ENTRIES: " + appendEntries + "\n" + "RESPONSE: " + reply))
                 .map(ResponseEntity::ok);
     }
 
@@ -62,14 +63,9 @@ public class RaftController implements InboundCommunication {
             produces = "application/json"
     )
     public Mono<ResponseEntity<RequestVoteReply>> requestVoteEndpoint(@RequestBody RequestVote requestVote) {
-
-        // log.info("\nREQUEST: " + requestVote.toString() + "\n" + "RESPONSE: " + reply);
-
-        // log.info("\nREQUEST: " + requestVote.toString());
-
         return this.requestVote(requestVote)
+                .doOnNext(reply -> log.info("\nREQUEST VOTE: " + requestVote + "\n" + "RESPONSE: " + reply))
                 .map(ResponseEntity::ok);
-
     }
 
     /* --------------------------------------------------- */

--- a/reactive/src/main/java/com/springRaft/reactive/communication/inbound/RaftController.java
+++ b/reactive/src/main/java/com/springRaft/reactive/communication/inbound/RaftController.java
@@ -76,7 +76,7 @@ public class RaftController implements InboundCommunication {
 
     @Override
     public Mono<AppendEntriesReply> appendEntries(AppendEntries appendEntries) {
-        return null;
+        return this.consensusModule.appendEntries(appendEntries);
     }
 
     @Override

--- a/reactive/src/main/java/com/springRaft/reactive/communication/inbound/RaftController.java
+++ b/reactive/src/main/java/com/springRaft/reactive/communication/inbound/RaftController.java
@@ -1,5 +1,7 @@
 package com.springRaft.reactive.communication.inbound;
 
+import com.springRaft.reactive.communication.message.AppendEntries;
+import com.springRaft.reactive.communication.message.AppendEntriesReply;
 import com.springRaft.reactive.communication.message.RequestVote;
 import com.springRaft.reactive.communication.message.RequestVoteReply;
 import com.springRaft.reactive.consensusModule.ConsensusModule;
@@ -47,6 +49,11 @@ public class RaftController implements InboundCommunication {
     }
 
     /* --------------------------------------------------- */
+
+    @Override
+    public Mono<AppendEntriesReply> appendEntries(AppendEntries appendEntries) {
+        return null;
+    }
 
     @Override
     public Mono<RequestVoteReply> requestVote(RequestVote requestVote) {

--- a/reactive/src/main/java/com/springRaft/reactive/communication/message/AppendEntries.java
+++ b/reactive/src/main/java/com/springRaft/reactive/communication/message/AppendEntries.java
@@ -1,0 +1,37 @@
+package com.springRaft.reactive.communication.message;
+
+import com.springRaft.reactive.persistence.log.Entry;
+import lombok.*;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@Scope("prototype")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class AppendEntries implements Message {
+
+    /* Leader's term */
+    private Long term;
+
+    /* So follower can redirect clients */
+    private String leaderId;
+
+    /* Index of log entry immediately preceding new ones */
+    private Long prevLogIndex;
+
+    /* Term of prevLogIndex entry */
+    private Long prevLogTerm;
+
+    /* Log entries to store (empty for heartbeat; may send more than one for efficiency) */
+    private List<Entry> entries;
+
+    /* Leader’s commitIndex */
+    private Long leaderCommit;
+
+}

--- a/reactive/src/main/java/com/springRaft/reactive/communication/message/AppendEntriesReply.java
+++ b/reactive/src/main/java/com/springRaft/reactive/communication/message/AppendEntriesReply.java
@@ -1,0 +1,22 @@
+package com.springRaft.reactive.communication.message;
+
+import lombok.*;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope("prototype")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class AppendEntriesReply implements Message {
+
+    /* CurrentTerm, for leader to update itself */
+    private Long term;
+
+    /* True if follower contained entry matching prevLogIndex and prevLogTerm */
+    private Boolean success;
+
+}

--- a/reactive/src/main/java/com/springRaft/reactive/communication/outbound/OutboundContext.java
+++ b/reactive/src/main/java/com/springRaft/reactive/communication/outbound/OutboundContext.java
@@ -1,5 +1,7 @@
 package com.springRaft.reactive.communication.outbound;
 
+import com.springRaft.reactive.communication.message.AppendEntries;
+import com.springRaft.reactive.communication.message.AppendEntriesReply;
 import com.springRaft.reactive.communication.message.RequestVote;
 import com.springRaft.reactive.communication.message.RequestVoteReply;
 import lombok.NoArgsConstructor;
@@ -22,6 +24,11 @@ public class OutboundContext implements OutboundStrategy {
     }
 
     /* --------------------------------------------------- */
+
+    @Override
+    public Mono<AppendEntriesReply> appendEntries(String to, AppendEntries message) {
+        return this.communicationStrategy.appendEntries(to, message);
+    }
 
     @Override
     public Mono<RequestVoteReply> requestVote(String to, RequestVote message) {

--- a/reactive/src/main/java/com/springRaft/reactive/communication/outbound/OutboundStrategy.java
+++ b/reactive/src/main/java/com/springRaft/reactive/communication/outbound/OutboundStrategy.java
@@ -1,5 +1,7 @@
 package com.springRaft.reactive.communication.outbound;
 
+import com.springRaft.reactive.communication.message.AppendEntries;
+import com.springRaft.reactive.communication.message.AppendEntriesReply;
 import com.springRaft.reactive.communication.message.RequestVote;
 import com.springRaft.reactive.communication.message.RequestVoteReply;
 import reactor.core.publisher.Mono;
@@ -7,7 +9,22 @@ import reactor.core.publisher.Mono;
 public interface OutboundStrategy {
 
     /**
-     * TODO
+     * Abstract method for the outbound strategies implement it, so they can send appendEntriesRPC.
+     *
+     * @param to Target server name.
+     * @param message AppendEntries message to send.
+     *
+     * @return Mono<AppendEntriesReply> Reply to handle internally.
+     * */
+    Mono<AppendEntriesReply> appendEntries(String to, AppendEntries message);
+
+    /**
+     * Abstract method for the outbound strategies implement it, so they can send requestVoteRPC.
+     *
+     * @param to Target server name.
+     * @param message RequestVote message to send.
+     *
+     * @return Mono<RequestVoteReply> Reply to handle internally.
      * */
     Mono<RequestVoteReply> requestVote(String to, RequestVote message);
 

--- a/reactive/src/main/java/com/springRaft/reactive/communication/outbound/REST.java
+++ b/reactive/src/main/java/com/springRaft/reactive/communication/outbound/REST.java
@@ -1,16 +1,12 @@
 package com.springRaft.reactive.communication.outbound;
 
-import com.springRaft.reactive.communication.message.Message;
-import com.springRaft.reactive.communication.message.RequestVote;
-import com.springRaft.reactive.communication.message.RequestVoteReply;
+import com.springRaft.reactive.communication.message.*;
 import com.springRaft.reactive.config.RaftProperties;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
-
-import java.time.Duration;
 
 @Service
 public class REST implements OutboundStrategy {
@@ -32,6 +28,11 @@ public class REST implements OutboundStrategy {
     }
 
     /* --------------------------------------------------- */
+
+    @Override
+    public Mono<AppendEntriesReply> appendEntries(String to, AppendEntries message) {
+        return (Mono<AppendEntriesReply>) sendPostToServer(to, "appendEntries", message, AppendEntriesReply.class);
+    }
 
     @Override
     public Mono<RequestVoteReply> requestVote(String to, RequestVote message) {

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/Candidate.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/Candidate.java
@@ -1,8 +1,6 @@
 package com.springRaft.reactive.consensusModule;
 
-import com.springRaft.reactive.communication.message.Message;
-import com.springRaft.reactive.communication.message.RequestVote;
-import com.springRaft.reactive.communication.message.RequestVoteReply;
+import com.springRaft.reactive.communication.message.*;
 import com.springRaft.reactive.communication.outbound.OutboundManager;
 import com.springRaft.reactive.config.RaftProperties;
 import com.springRaft.reactive.persistence.log.LogService;
@@ -55,6 +53,16 @@ public class Candidate extends RaftStateContext implements RaftState {
     }
 
     /* --------------------------------------------------- */
+
+    @Override
+    public Mono<AppendEntriesReply> appendEntries(AppendEntries appendEntries) {
+        return null;
+    }
+
+    @Override
+    public Mono<Void> appendEntriesReply(AppendEntriesReply appendEntriesReply, String from) {
+        return null;
+    }
 
     @Override
     public Mono<RequestVoteReply> requestVote(RequestVote requestVote) {

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/Candidate.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/Candidate.java
@@ -56,7 +56,7 @@ public class Candidate extends RaftStateContext implements RaftState {
 
     @Override
     public Mono<AppendEntriesReply> appendEntries(AppendEntries appendEntries) {
-        return null;
+        return super.appendEntries(appendEntries);
     }
 
     @Override
@@ -208,6 +208,16 @@ public class Candidate extends RaftStateContext implements RaftState {
 
                 })
                 .doOnTerminate(this::setTimeout);
+
+    }
+
+    /* --------------------------------------------------- */
+
+    @Override
+    protected Mono<Void> postAppendEntries(AppendEntries appendEntries) {
+
+        // transit to follower state
+        return this.cleanBeforeTransit().doOnTerminate(this.transitionManager::setNewFollowerState);
 
     }
 

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/ConsensusModule.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/ConsensusModule.java
@@ -1,8 +1,6 @@
 package com.springRaft.reactive.consensusModule;
 
-import com.springRaft.reactive.communication.message.Message;
-import com.springRaft.reactive.communication.message.RequestVote;
-import com.springRaft.reactive.communication.message.RequestVoteReply;
+import com.springRaft.reactive.communication.message.*;
 import com.springRaft.reactive.util.Pair;
 import lombok.Getter;
 import lombok.Synchronized;
@@ -37,6 +35,18 @@ public class ConsensusModule implements RaftState {
     }
 
     /* --------------------------------------------------- */
+
+    @Override
+    @Synchronized
+    public Mono<AppendEntriesReply> appendEntries(AppendEntries appendEntries) {
+        return this.current.appendEntries(appendEntries);
+    }
+
+    @Override
+    @Synchronized
+    public Mono<Void> appendEntriesReply(AppendEntriesReply appendEntriesReply, String from) {
+        return this.current.appendEntriesReply(appendEntriesReply, from);
+    }
 
     @Override
     @Synchronized

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/Follower.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/Follower.java
@@ -1,8 +1,6 @@
 package com.springRaft.reactive.consensusModule;
 
-import com.springRaft.reactive.communication.message.Message;
-import com.springRaft.reactive.communication.message.RequestVote;
-import com.springRaft.reactive.communication.message.RequestVoteReply;
+import com.springRaft.reactive.communication.message.*;
 import com.springRaft.reactive.communication.outbound.OutboundManager;
 import com.springRaft.reactive.config.RaftProperties;
 import com.springRaft.reactive.persistence.log.LogService;
@@ -51,6 +49,16 @@ public class Follower extends RaftStateContext implements RaftState {
     }
 
     /* --------------------------------------------------- */
+
+    @Override
+    public Mono<AppendEntriesReply> appendEntries(AppendEntries appendEntries) {
+        return null;
+    }
+
+    @Override
+    public Mono<Void> appendEntriesReply(AppendEntriesReply appendEntriesReply, String from) {
+        return null;
+    }
 
     @Override
     public Mono<RequestVoteReply> requestVote(RequestVote requestVote) {

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/Leader.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/Leader.java
@@ -67,7 +67,51 @@ public class Leader extends RaftStateContext implements RaftState {
 
     @Override
     public Mono<Void> appendEntriesReply(AppendEntriesReply appendEntriesReply, String from) {
-        return null;
+
+        if (appendEntriesReply.getSuccess()) {
+
+            return Mono.empty();
+
+        } else {
+
+            return this.stateService.getCurrentTerm()
+                    .flatMap(currentTerm -> {
+
+                        // if term is greater than mine, I should update it and transit to new follower
+                        if (appendEntriesReply.getTerm() > currentTerm) {
+
+                            return this.stateService.setState(appendEntriesReply.getTerm(), null)
+                                    .doOnTerminate(() -> {
+
+                                        // clean leader's state
+                                        this.cleanVolatileState();
+
+                                        // transit to follower state
+                                        this.transitionManager.setNewFollowerState();
+
+                                        // deactivate PeerWorker
+                                        this.outboundManager.clearMessages().subscribe();
+
+                                    })
+                                    .then();
+
+                        } else {
+
+                            return Mono.defer(() -> {
+
+                                this.nextIndex.put(from, this.nextIndex.get(from) - 1);
+                                this.matchIndex.put(from, (long) 0);
+
+                                return Mono.empty();
+
+                            });
+
+                        }
+
+                    });
+
+        }
+
     }
 
     @Override

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/Leader.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/Leader.java
@@ -62,7 +62,7 @@ public class Leader extends RaftStateContext implements RaftState {
 
     @Override
     public Mono<AppendEntriesReply> appendEntries(AppendEntries appendEntries) {
-        return null;
+        return super.appendEntries(appendEntries);
     }
 
     @Override
@@ -209,6 +209,25 @@ public class Leader extends RaftStateContext implements RaftState {
                     this.outboundManager.newMessage().subscribe();
 
                 });
+
+    }
+
+    /* --------------------------------------------------- */
+
+    @Override
+    protected Mono<Void> postAppendEntries(AppendEntries appendEntries) {
+
+        // deactivate PeerWorker
+        return this.outboundManager.clearMessages()
+                .doFirst(() -> {
+
+                    this.cleanVolatileState();
+
+                    // transit to follower state
+                    this.transitionManager.setNewFollowerState();
+
+                });
+
 
     }
 

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/Leader.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/Leader.java
@@ -1,9 +1,6 @@
 package com.springRaft.reactive.consensusModule;
 
-import com.springRaft.reactive.communication.message.AppendEntries;
-import com.springRaft.reactive.communication.message.Message;
-import com.springRaft.reactive.communication.message.RequestVote;
-import com.springRaft.reactive.communication.message.RequestVoteReply;
+import com.springRaft.reactive.communication.message.*;
 import com.springRaft.reactive.communication.outbound.OutboundManager;
 import com.springRaft.reactive.config.RaftProperties;
 import com.springRaft.reactive.persistence.log.Entry;
@@ -62,6 +59,16 @@ public class Leader extends RaftStateContext implements RaftState {
     }
 
     /* --------------------------------------------------- */
+
+    @Override
+    public Mono<AppendEntriesReply> appendEntries(AppendEntries appendEntries) {
+        return null;
+    }
+
+    @Override
+    public Mono<Void> appendEntriesReply(AppendEntriesReply appendEntriesReply, String from) {
+        return null;
+    }
 
     @Override
     public Mono<RequestVoteReply> requestVote(RequestVote requestVote) {

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/Leader.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/Leader.java
@@ -1,11 +1,15 @@
 package com.springRaft.reactive.consensusModule;
 
+import com.springRaft.reactive.communication.message.AppendEntries;
 import com.springRaft.reactive.communication.message.Message;
 import com.springRaft.reactive.communication.message.RequestVote;
 import com.springRaft.reactive.communication.message.RequestVoteReply;
 import com.springRaft.reactive.communication.outbound.OutboundManager;
 import com.springRaft.reactive.config.RaftProperties;
+import com.springRaft.reactive.persistence.log.Entry;
 import com.springRaft.reactive.persistence.log.LogService;
+import com.springRaft.reactive.persistence.log.LogState;
+import com.springRaft.reactive.persistence.state.State;
 import com.springRaft.reactive.persistence.state.StateService;
 import com.springRaft.reactive.util.Pair;
 import org.slf4j.Logger;
@@ -16,7 +20,9 @@ import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -142,7 +148,47 @@ public class Leader extends RaftStateContext implements RaftState {
 
     @Override
     public Mono<Pair<Message, Boolean>> getNextMessage(String to) {
-        return null;
+
+        return Mono.defer(() ->
+                Mono.just(new Pair<>(this.nextIndex.get(to), this.matchIndex.get(to)))
+        )
+                .flatMap(pair -> {
+
+                    // get next index for specific "to" server
+                    Long nextIndex = pair.getFirst();
+                    Long matchIndex = pair.getSecond();
+
+                    return this.logService.getEntryByIndex(nextIndex)
+                            .switchIfEmpty(
+                                    Mono.defer(() ->
+                                        Mono.just(new Entry(null, null, null, false))
+                                    )
+                            )
+                            .flatMap(entry -> {
+
+                                if (entry.getIndex() == null && matchIndex == (nextIndex - 1)) {
+                                    // if there is no entry in log then send heartbeat
+
+                                    return this.heartbeatAppendEntries()
+                                            .map(message -> new Pair<>(message, true));
+
+                                } else if(entry.getIndex() == null) {
+                                    // if there is no entry and the logs are not matching
+
+                                    return this.heartbeatAppendEntries()
+                                            .map(message -> new Pair<>(message, false));
+
+                                } else {
+
+                                    return this.heartbeatAppendEntries()
+                                            .map(message -> new Pair<>(message, true));
+
+                                }
+
+                            });
+
+                });
+
     }
 
     @Override
@@ -181,7 +227,7 @@ public class Leader extends RaftStateContext implements RaftState {
 
                     // this.nextIndex.put(serverName, defaultNextIndex);
 
-                    this.nextIndex.put(serverName, (long) 0);
+                    this.nextIndex.put(serverName, (long) 1);
                     this.matchIndex.put(serverName, (long) 0);
 
                 })
@@ -196,6 +242,52 @@ public class Leader extends RaftStateContext implements RaftState {
 
         this.nextIndex = new HashMap<>();
         this.matchIndex = new HashMap<>();
+
+    }
+
+    /**
+     * Method that creates an AppendEntries with no entries that represents an heartbeat.
+     *
+     * @return AppendEntries Message to pass to an up-to-date follower.
+     * */
+    private Mono<AppendEntries> heartbeatAppendEntries() {
+
+        Mono<State> stateMono = this.stateService.getState();
+        Mono<LogState> logStateMono = this.logService.getState();
+        Mono<Entry> lastEntryMono = this.logService.getLastEntry();
+
+        return Mono.zip(stateMono, logStateMono, lastEntryMono)
+                .flatMap(tuple ->
+                        this.createAppendEntries(tuple.getT1(), tuple.getT2(), tuple.getT3(), new ArrayList<>())
+                );
+
+    }
+
+    /**
+     * Method that creates an AppendEntries with the new entry.
+     *
+     * @param state State for getting current term.
+     * @param logState Log state for getting the committed index.
+     * @param lastEntry Last Entry in the log for getting its index and term.
+     * @param entries Entries to send in the AppendEntries.
+     *
+     * @return AppendEntries Message to pass to another server.
+     * */
+    private Mono<AppendEntries> createAppendEntries(State state, LogState logState, Entry lastEntry, List<Entry> entries) {
+
+        return Mono.defer(() ->
+                Mono.just(
+                    this.applicationContext.getBean(
+                        AppendEntries.class,
+                        state.getCurrentTerm(), // term
+                        this.raftProperties.getHost(), // leaderId
+                        lastEntry.getIndex(), // prevLogIndex
+                        lastEntry.getTerm(), // prevLogTerm
+                        entries, // entries
+                        logState.getCommittedIndex() // leaderCommit
+                    )
+                )
+        );
 
     }
 

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/RaftState.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/RaftState.java
@@ -1,12 +1,29 @@
 package com.springRaft.reactive.consensusModule;
 
-import com.springRaft.reactive.communication.message.Message;
-import com.springRaft.reactive.communication.message.RequestVote;
-import com.springRaft.reactive.communication.message.RequestVoteReply;
+import com.springRaft.reactive.communication.message.*;
 import com.springRaft.reactive.util.Pair;
 import reactor.core.publisher.Mono;
 
 public interface RaftState {
+
+    /**
+     * Method for handling AppendEntries RPC
+     *
+     * @param appendEntries AppendEntries object sent from leader.
+     *
+     * @return Mono<AppendEntriesReply> Reply for the AppendEntries.
+     * */
+    Mono<AppendEntriesReply> appendEntries(AppendEntries appendEntries);
+
+    /**
+     * Method for handling AppendEntries replies.
+     *
+     * @param appendEntriesReply AppendEntriesReply object sent from other servers.
+     * @param from String that identifies the server that sent the reply.
+     *
+     * @return A Mono to be subscribed.
+     * */
+    Mono<Void> appendEntriesReply(AppendEntriesReply appendEntriesReply, String from);
 
     /**
      * Method for handling RequestVote RPC.
@@ -21,7 +38,8 @@ public interface RaftState {
      * Method for handling RequestVote replies.
      *
      * @param requestVoteReply RequestVoteReply object sent from other servers.
-     * @return
+     *
+     * @return A Mono to be subscribed.
      */
     Mono<Void> requestVoteReply(RequestVoteReply requestVoteReply);
 

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/RaftStateContext.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/RaftStateContext.java
@@ -1,10 +1,14 @@
 package com.springRaft.reactive.consensusModule;
 
+import com.springRaft.reactive.communication.message.AppendEntries;
+import com.springRaft.reactive.communication.message.AppendEntriesReply;
 import com.springRaft.reactive.communication.message.RequestVote;
 import com.springRaft.reactive.communication.message.RequestVoteReply;
 import com.springRaft.reactive.communication.outbound.OutboundManager;
 import com.springRaft.reactive.config.RaftProperties;
+import com.springRaft.reactive.persistence.log.Entry;
 import com.springRaft.reactive.persistence.log.LogService;
+import com.springRaft.reactive.persistence.state.State;
 import com.springRaft.reactive.persistence.state.StateService;
 import lombok.AllArgsConstructor;
 import org.slf4j.Logger;
@@ -117,6 +121,104 @@ public abstract class RaftStateContext {
                 });
 
     }
+
+    /* --------------------------------------------------- */
+
+    /**
+     * TODO
+     * */
+    protected Mono<AppendEntriesReply> appendEntries(AppendEntries appendEntries) {
+
+        Mono<AppendEntriesReply> replyMono = Mono.defer(
+                () -> Mono.just(this.applicationContext.getBean(AppendEntriesReply.class))
+        );
+
+        Mono<Long> currentTermMono = this.stateService.getCurrentTerm();
+
+        return Mono.zip(replyMono, currentTermMono)
+                .flatMap(tuple -> {
+
+                    AppendEntriesReply reply = tuple.getT1();
+                    long currentTerm = tuple.getT2();
+
+                    if (appendEntries.getTerm() < currentTerm) {
+
+                        reply.setTerm(currentTerm);
+                        reply.setSuccess(false);
+
+                        return Mono.defer(() -> Mono.just(reply));
+
+                    } else {
+
+                        Mono<State> stateMono = Mono.just(new State(null, null, null, true));
+
+                        if (appendEntries.getTerm() > currentTerm) {
+                            // update term
+                            stateMono = this.stateService.setState(appendEntries.getTerm(), null);
+                        }
+
+                        return stateMono.flatMap(state ->
+                            this.setAppendEntriesReply(appendEntries, reply)
+                                    .doOnTerminate(() -> this.postAppendEntries(appendEntries).subscribe())
+                        );
+
+                    }
+
+                });
+
+    }
+
+    /**
+     * A method that encapsulates replicated code, and has the function of setting
+     * the reply for the received AppendEntries.
+     *
+     * @param appendEntries The received AppendEntries communication.
+     * @param reply AppendEntriesReply object, to send as response to the leader.
+     * */
+    private Mono<AppendEntriesReply> setAppendEntriesReply(AppendEntries appendEntries, AppendEntriesReply reply) {
+
+        return this.logService.getEntryByIndex(appendEntries.getPrevLogIndex())
+                .switchIfEmpty(Mono.just(new Entry((long) 0, (long) 0, null, false)))
+                .doFirst(() -> {
+                    // reply with the current term
+                    reply.setTerm(appendEntries.getTerm());
+                })
+                .flatMap(entry -> {
+
+                    if(entry.getIndex() == (long) appendEntries.getPrevLogIndex()) {
+
+                        if (entry.getTerm() == (long) appendEntries.getPrevLogTerm()) {
+
+                            reply.setSuccess(true);
+
+                            // this.applyAppendEntries(appendEntries);
+
+                        } else {
+
+                            reply.setSuccess(false);
+
+                        }
+
+                    } else {
+
+                        reply.setSuccess(false);
+
+                    }
+
+                    return Mono.defer(() -> Mono.just(reply));
+
+                });
+
+    }
+
+    /**
+     * Abstract method for the Raft state to implement it for post execution operations.
+     *
+     * @param appendEntries The received AppendEntries communication.
+     *
+     * @return Mono<Void> The result is not important, but it needs to be subscribed.
+     * */
+    protected abstract Mono<Void> postAppendEntries(AppendEntries appendEntries);
 
     /* --------------------------------------------------- */
 

--- a/reactive/src/main/java/com/springRaft/reactive/persistence/log/Entry.java
+++ b/reactive/src/main/java/com/springRaft/reactive/persistence/log/Entry.java
@@ -1,0 +1,55 @@
+package com.springRaft.reactive.persistence.log;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Transient;
+import org.springframework.data.domain.Persistable;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@ToString
+public class Entry implements Persistable<Long> {
+
+    /* Index of an Entry in the log */
+    @Id
+    private Long index;
+
+    /* Term in which this entry was inserted */
+    private Long term;
+
+    /* Command to apply to the state machine */
+    private String command;
+
+    /* Transient flag that states ith the object is new or already in database */
+    @Transient
+    private boolean isNew;
+
+    /* --------------------------------------------------- */
+
+    /**
+     * Specific constructor for creating a parametrized entry.
+     * */
+    public Entry(Long term, String command) {
+        this.index = null;
+        this.term = term;
+        this.command = command;
+    }
+
+    /* --------------------------------------------------- */
+
+    @Override
+    public Long getId() {
+        return this.index;
+    }
+
+    @Override
+    public boolean isNew() {
+        return isNew;
+    }
+
+}

--- a/reactive/src/main/java/com/springRaft/reactive/persistence/log/EntryRepository.java
+++ b/reactive/src/main/java/com/springRaft/reactive/persistence/log/EntryRepository.java
@@ -20,7 +20,7 @@ public interface EntryRepository extends ReactiveCrudRepository<Entry,Long> {
      *
      * @return Entry Last log entry.
      * */
-    @Query("SELECT entry FROM Entry entry WHERE entry.index = (SELECT MAX(entry.index) FROM Entry entry)")
+    @Query("SELECT * FROM Entry entry WHERE entry.index = (SELECT MAX(entry.index) FROM Entry entry)")
     Mono<Entry> findLastEntry();
 
     /**
@@ -31,7 +31,7 @@ public interface EntryRepository extends ReactiveCrudRepository<Entry,Long> {
      *
      * @return List of the Entries found.
      * */
-    @Query("SELECT entry FROM Entry entry WHERE entry.index >= ?1 AND entry.index < ?2")
+    @Query("SELECT * FROM Entry entry WHERE entry.index >= ?1 AND entry.index < ?2")
     Flux<Entry> getNextEntries(Long minIndex, Long maxIndex);
 
     /**

--- a/reactive/src/main/java/com/springRaft/reactive/persistence/log/EntryRepository.java
+++ b/reactive/src/main/java/com/springRaft/reactive/persistence/log/EntryRepository.java
@@ -1,0 +1,44 @@
+package com.springRaft.reactive.persistence.log;
+
+import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface EntryRepository extends ReactiveCrudRepository<Entry,Long> {
+
+    /**
+     * Select method for find the last entry's index in the log.
+     *
+     * @return Long Index of the last entry.
+     * */
+    @Query("SELECT MAX(entry.index) FROM Entry entry")
+    Mono<Long> findLastEntryIndex();
+
+    /**
+     * Select method for getting the last entry in the log.
+     *
+     * @return Entry Last log entry.
+     * */
+    @Query("SELECT entry FROM Entry entry WHERE entry.index = (SELECT MAX(entry.index) FROM Entry entry)")
+    Mono<Entry> findLastEntry();
+
+    /**
+     * Method that gets the entries between two indexes.
+     *
+     * @param minIndex Index to begin the search.
+     * @param maxIndex Index to stop the search.
+     *
+     * @return List of the Entries found.
+     * */
+    @Query("SELECT entry FROM Entry entry WHERE entry.index >= ?1 AND entry.index < ?2")
+    Flux<Entry> getNextEntries(Long minIndex, Long maxIndex);
+
+    /**
+     * Delete Method for deleting entries with an index greater than a specific number.
+     *
+     * @param index Long that represents the index from which the following will be deleted.
+     * */
+    Mono<Void> deleteEntryByIndexGreaterThan(Long index);
+
+}

--- a/reactive/src/main/java/com/springRaft/reactive/persistence/log/LogService.java
+++ b/reactive/src/main/java/com/springRaft/reactive/persistence/log/LogService.java
@@ -1,6 +1,5 @@
 package com.springRaft.reactive.persistence.log;
 
-import com.springRaft.reactive.persistence.state.StateService;
 import lombok.AllArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +16,9 @@ public class LogService {
 
     /* Logger */
     private static final Logger log = LoggerFactory.getLogger(LogService.class);
+
+    /* Repository for Entry operations */
+    private final EntryRepository entryRepository;
 
     /* Repository for Entry operations */
     private final LogStateRepository logStateRepository;

--- a/reactive/src/main/java/com/springRaft/reactive/persistence/log/LogService.java
+++ b/reactive/src/main/java/com/springRaft/reactive/persistence/log/LogService.java
@@ -45,4 +45,29 @@ public class LogService {
                 .doOnError(error -> log.error("\nError on saveState method: \n" + error));
     }
 
+    /* --------------------------------------------------- */
+
+    /**
+     * Method for getting an entry with a specific index.
+     *
+     * @param index Long which is the index of the entry in the log.
+     *
+     * @return Mono<Entry> Entry found in that specific index.
+     * */
+    public Mono<Entry> getEntryByIndex(Long index) {
+        return this.entryRepository.findById(index);
+    }
+
+    /**
+     * Method that gets the last entry in the log.
+     *
+     * @return Mono<Entry> Last entry in the log.
+     * */
+    public Mono<Entry> getLastEntry() {
+        return this.entryRepository.findLastEntry()
+                .switchIfEmpty(
+                        Mono.just(new Entry((long) 0, (long) 0, null, false))
+                );
+    }
+
 }

--- a/reactive/src/main/java/com/springRaft/reactive/worker/PeerWorker.java
+++ b/reactive/src/main/java/com/springRaft/reactive/worker/PeerWorker.java
@@ -1,5 +1,6 @@
 package com.springRaft.reactive.worker;
 
+import com.springRaft.reactive.communication.message.AppendEntries;
 import com.springRaft.reactive.communication.message.Message;
 import com.springRaft.reactive.communication.message.RequestVote;
 import com.springRaft.reactive.communication.message.RequestVoteReply;
@@ -164,26 +165,28 @@ public class PeerWorker implements Runnable, MessageSubscriber {
 
             this.handleRequestVote((RequestVote) message);
 
-        } /*else if (message instanceof AppendEntries) {
+        } else if (message instanceof AppendEntries) {
 
             if (heartbeat) {
                 // if it is an heartbeat
 
                 this.handleHeartbeat((AppendEntries) message);
 
-            } else {
+            } /*else {
                 // if it has an Entry to add to the log or it is an AppendEntries to find a match index
 
                 this.handleNormalAppendEntries((AppendEntries) message);
 
-            }
+            }*/
 
-        }*/
+        }
 
     }
 
     /**
-     * TODO
+     * Method that handles the requestVoteRPC communication.
+     *
+     * @param requestVote Message to send to the target server.
      * */
     private void handleRequestVote(RequestVote requestVote) {
 
@@ -201,6 +204,18 @@ public class PeerWorker implements Runnable, MessageSubscriber {
                     .flatMap(result -> this.clearMessages())
                     .block();
         }
+
+    }
+
+    private void handleHeartbeat(AppendEntries appendEntries) {
+
+        RequestVoteReply reply;
+
+        do {
+
+
+
+        } while (this.active && this.remainingMessages == 0);
 
     }
 

--- a/reactive/src/main/resources/schema-h2.sql
+++ b/reactive/src/main/resources/schema-h2.sql
@@ -12,3 +12,10 @@ CREATE TABLE IF NOT EXISTS log_state (
     last_applied BIGINT(255),
     PRIMARY KEY (id)
 );
+
+CREATE TABLE IF NOT EXISTS entry (
+    index BIGINT(255),
+    term BIGINT(255),
+    command VARCHAR(max),
+    PRIMARY KEY (index)
+);


### PR DESCRIPTION
This PR finishes the Leader Election subproblem of Raft's algorithm, and adds:

- AppendEntries endpoint for AppendEntries RPC communications;
- Add Entry entity, its DAO and a logService for interact with log entries, and log state.
- PeerWorker handling of heartbeats;

Resolves: #71 