### PR TITLE
Reactive - Handling Client Requests

### DIFF
--- a/reactive/src/main/java/com/springRaft/reactive/communication/inbound/EmbeddedController.java
+++ b/reactive/src/main/java/com/springRaft/reactive/communication/inbound/EmbeddedController.java
@@ -1,0 +1,94 @@
+package com.springRaft.reactive.communication.inbound;
+
+import com.springRaft.reactive.communication.outbound.OutboundContext;
+import com.springRaft.reactive.config.RaftProperties;
+import lombok.AllArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("raft")
+@ConditionalOnProperty(name = "raft.state-machine-strategy", havingValue = "EMBEDDED")
+@AllArgsConstructor
+public class EmbeddedController {
+
+    /* Main controller that communicates with consensus module */
+    private final RaftController raftController;
+
+    /* Raft properties that need to be accessed */
+    private final RaftProperties raftProperties;
+
+    /* Outbound context for communication to other servers */
+    protected final OutboundContext outbound;
+
+    /* --------------------------------------------------- */
+
+    /**
+     * Method that handles all the calls on whatever endpoint not defined in any other controller.
+     *
+     * @param body String that represents the body of the request.
+     * @param request ServerHttpRequest object that contains all the information about the request.
+     *
+     * @return Mono<ResponseEntity<?>> A response entity which includes the reply to the request made.
+     * */
+    @RequestMapping(value = "**")
+    public Mono<ResponseEntity<?>> clientRequestEndpoint(@RequestBody(required = false) String body, ServerHttpRequest request) {
+
+        return Mono.defer(() ->
+                Mono.just(request.getMethod() + ";;;" + request.getPath() + ";;;" + body)
+        )
+                .flatMap(command ->
+
+                    this.raftController.clientRequest(command)
+                        .flatMap(requestReply -> {
+
+                            System.out.println("\n\ncommand: " + command);
+
+                            if (requestReply.getSuccess()) {
+                                // if the reply is successful just return the response
+
+                                return Mono.just((ResponseEntity<?>) requestReply.getResponse());
+
+                            } else {
+
+                                if (requestReply.getRedirect()) {
+                                    // send a request to leader, because I'm a follower
+
+                                    return (Mono<ResponseEntity<?>>) this.outbound.request(
+                                            command.replaceFirst("/raft", ""),
+                                            requestReply.getRedirectTo());
+
+
+                                } else {
+                                    // if I'm a candidate, I cant redirect to anyone
+
+                                    return Mono.defer(() -> {
+
+                                        HttpHeaders httpHeaders = new HttpHeaders();
+                                        httpHeaders.set(
+                                                HttpHeaders.RETRY_AFTER,
+                                                Long.toString(this.raftProperties.getHeartbeat().toMillis() / 1000)
+                                        );
+
+                                        return Mono.just(new ResponseEntity<>(httpHeaders, HttpStatus.SERVICE_UNAVAILABLE));
+
+                                    });
+
+                                }
+
+                            }
+
+                        })
+
+                );
+
+    }
+
+}

--- a/reactive/src/main/java/com/springRaft/reactive/communication/inbound/EmbeddedFilter.java
+++ b/reactive/src/main/java/com/springRaft/reactive/communication/inbound/EmbeddedFilter.java
@@ -1,0 +1,121 @@
+package com.springRaft.reactive.communication.inbound;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+
+@Component
+@ConditionalOnProperty(name = "raft.state-machine-strategy", havingValue = "EMBEDDED")
+public class EmbeddedFilter implements WebFilter {
+
+    /* Requests prefix */
+    private static final String REQUEST_PREFIX = "/raft";
+
+    /* Endpoints to exclude */
+    private static final String[] excludedEndpoints = new String[] {"/raft/appendEntries", "/raft/requestVote"};
+
+    /* --------------------------------------------------- */
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange serverWebExchange, WebFilterChain webFilterChain) {
+
+        return Mono.defer(() -> Mono.just(serverWebExchange.getRequest()))
+                .flatMap(request -> {
+
+                    if (this.shouldNotFilter(request)) {
+
+                        return webFilterChain.filter(serverWebExchange);
+
+                    } else {
+
+                        if (!new AntPathMatcher().match(REQUEST_PREFIX + "/**", String.valueOf(request.getPath()))) {
+
+                            return this.addPrefix(serverWebExchange, webFilterChain, request);
+
+                        } else {
+
+                            return this.removePrefix(serverWebExchange, webFilterChain, request);
+
+                        }
+
+                    }
+
+                });
+
+    }
+
+    /* --------------------------------------------------- */
+
+    /**
+     * TODO
+     * */
+    private boolean shouldNotFilter(ServerHttpRequest request) {
+
+        return Arrays.stream(excludedEndpoints)
+                .anyMatch(e -> new AntPathMatcher().match(e, String.valueOf(request.getPath())));
+
+    }
+
+    /**
+     * TODO
+     * */
+    private Mono<Void> removePrefix(
+            ServerWebExchange serverWebExchange,
+            WebFilterChain webFilterChain,
+            ServerHttpRequest request)
+    {
+
+        try {
+
+            ServerHttpRequest newRequest = request.mutate()
+                    .path(String.valueOf(request.getPath()).replaceFirst(REQUEST_PREFIX, ""))
+                    .uri(new URI(String.valueOf(request.getURI()).replaceFirst(REQUEST_PREFIX, "")))
+                    .build();
+
+            return webFilterChain.filter(serverWebExchange.mutate().request(newRequest).build());
+
+        } catch (URISyntaxException e) {
+
+            return webFilterChain.filter(serverWebExchange);
+
+        }
+
+    }
+
+    /**
+     * TODO
+     * */
+    private Mono<Void> addPrefix(
+            ServerWebExchange serverWebExchange,
+            WebFilterChain webFilterChain,
+            ServerHttpRequest request)
+    {
+
+        try {
+
+            ServerHttpRequest newRequest = request.mutate()
+                    .path(REQUEST_PREFIX + request.getPath())
+                    .uri(new URI(String.valueOf(request.getURI())
+                            .replaceFirst(String.valueOf(request.getPath()), REQUEST_PREFIX + request.getPath())))
+                    .build();
+
+            return webFilterChain.filter(serverWebExchange.mutate().request(newRequest).build());
+
+        } catch (URISyntaxException e) {
+
+            return webFilterChain.filter(serverWebExchange);
+
+        }
+
+    }
+
+}

--- a/reactive/src/main/java/com/springRaft/reactive/communication/inbound/InboundCommunication.java
+++ b/reactive/src/main/java/com/springRaft/reactive/communication/inbound/InboundCommunication.java
@@ -1,9 +1,6 @@
 package com.springRaft.reactive.communication.inbound;
 
-import com.springRaft.reactive.communication.message.AppendEntries;
-import com.springRaft.reactive.communication.message.AppendEntriesReply;
-import com.springRaft.reactive.communication.message.RequestVote;
-import com.springRaft.reactive.communication.message.RequestVoteReply;
+import com.springRaft.reactive.communication.message.*;
 import reactor.core.publisher.Mono;
 
 public interface InboundCommunication {
@@ -27,4 +24,14 @@ public interface InboundCommunication {
      * @return Mono<RequestVoteReply> Reply to send to the server which invoke the communication.
      * */
     Mono<RequestVoteReply> requestVote(RequestVote requestVote);
+
+    /**
+     * Abstract method for the inbound strategies to implement it, so they can handle the reception
+     * of general requests.
+     *
+     * @param command String that contains the command to execute in the FSM.
+     *
+     * @return Mono<RequestReply> Reply ti send to the client who made the request.
+     * */
+    Mono<RequestReply> clientRequest(String command);
 }

--- a/reactive/src/main/java/com/springRaft/reactive/communication/inbound/IndependentController.java
+++ b/reactive/src/main/java/com/springRaft/reactive/communication/inbound/IndependentController.java
@@ -30,9 +30,13 @@ public class IndependentController {
     /* --------------------------------------------------- */
 
     /**
-     * TODO
+     * Method that handles all the calls on whatever endpoint not defined in any other controller.
      *
-     * @return*/
+     * @param body String that represents the body of the request.
+     * @param request ServerHttpRequest object that contains all the information about the request.
+     *
+     * @return Mono<ResponseEntity<?>> A response entity which includes the reply to the request made.
+     * */
     @RequestMapping(value = "**")
     public Mono<ResponseEntity<?>> clientRequestEndpoint(@RequestBody(required = false) String body, ServerHttpRequest request) {
 
@@ -56,9 +60,6 @@ public class IndependentController {
                                     // send a request to leader, because I'm a follower
 
                                     return (Mono<ResponseEntity<?>>) this.outbound.request(command, requestReply.getRedirectTo());
-                                                //.cast(ResponseEntity.class);
-
-                                    //return Mono.just((ResponseEntity<?>) requestReply.getResponse());
 
 
                                 } else {

--- a/reactive/src/main/java/com/springRaft/reactive/communication/inbound/IndependentController.java
+++ b/reactive/src/main/java/com/springRaft/reactive/communication/inbound/IndependentController.java
@@ -1,0 +1,89 @@
+package com.springRaft.reactive.communication.inbound;
+
+import com.springRaft.reactive.communication.outbound.OutboundContext;
+import com.springRaft.reactive.config.RaftProperties;
+import lombok.AllArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@ConditionalOnProperty(name = "raft.state-machine-strategy", havingValue = "INDEPENDENT")
+@AllArgsConstructor
+public class IndependentController {
+
+    /* Main controller that communicates with consensus module */
+    private final RaftController raftController;
+
+    /* Raft properties that need to be accessed */
+    private final RaftProperties raftProperties;
+
+    /* Outbound context for communication to other servers */
+    protected final OutboundContext outbound;
+
+    /* --------------------------------------------------- */
+
+    /**
+     * TODO
+     *
+     * @return*/
+    @RequestMapping(value = "**")
+    public Mono<ResponseEntity<?>> clientRequestEndpoint(@RequestBody(required = false) String body, ServerHttpRequest request) {
+
+        return Mono.defer(() ->
+                Mono.just(request.getMethod() + ";;;" + request.getPath() + ";;;" + body)
+        )
+                .flatMap(command ->
+
+                    this.raftController.clientRequest(command)
+                        .flatMap(requestReply -> {
+
+                            if (requestReply.getSuccess()) {
+                                // if the reply is successful just return the response
+
+                                return Mono.just((ResponseEntity<?>) requestReply.getResponse());
+
+                            } else {
+                                // if the reply is not successful, check whether it is to redirect or not
+
+                                if (requestReply.getRedirect()) {
+                                    // send a request to leader, because I'm a follower
+
+                                    return (Mono<ResponseEntity<?>>) this.outbound.request(command, requestReply.getRedirectTo());
+                                                //.cast(ResponseEntity.class);
+
+                                    //return Mono.just((ResponseEntity<?>) requestReply.getResponse());
+
+
+                                } else {
+                                    // if I'm a candidate, I cant redirect to anyone
+
+                                    return Mono.defer(() -> {
+
+                                        HttpHeaders httpHeaders = new HttpHeaders();
+                                        httpHeaders.set(
+                                                HttpHeaders.RETRY_AFTER,
+                                                Long.toString(this.raftProperties.getHeartbeat().toMillis() / 1000)
+                                        );
+
+                                        return Mono.just(new ResponseEntity<>(httpHeaders, HttpStatus.SERVICE_UNAVAILABLE));
+
+                                    });
+
+                                }
+
+                            }
+
+                        })
+
+                );
+
+    }
+
+}

--- a/reactive/src/main/java/com/springRaft/reactive/communication/inbound/RaftController.java
+++ b/reactive/src/main/java/com/springRaft/reactive/communication/inbound/RaftController.java
@@ -1,9 +1,6 @@
 package com.springRaft.reactive.communication.inbound;
 
-import com.springRaft.reactive.communication.message.AppendEntries;
-import com.springRaft.reactive.communication.message.AppendEntriesReply;
-import com.springRaft.reactive.communication.message.RequestVote;
-import com.springRaft.reactive.communication.message.RequestVoteReply;
+import com.springRaft.reactive.communication.message.*;
 import com.springRaft.reactive.consensusModule.ConsensusModule;
 import lombok.AllArgsConstructor;
 import org.slf4j.Logger;
@@ -78,6 +75,11 @@ public class RaftController implements InboundCommunication {
     @Override
     public Mono<RequestVoteReply> requestVote(RequestVote requestVote) {
         return this.consensusModule.requestVote(requestVote);
+    }
+
+    @Override
+    public Mono<RequestReply> clientRequest(String command) {
+        return this.consensusModule.clientRequest(command);
     }
 
 }

--- a/reactive/src/main/java/com/springRaft/reactive/communication/message/RequestReply.java
+++ b/reactive/src/main/java/com/springRaft/reactive/communication/message/RequestReply.java
@@ -1,0 +1,28 @@
+package com.springRaft.reactive.communication.message;
+
+import lombok.*;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope("prototype")
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+public class RequestReply implements Message {
+
+    /* Success of the request */
+    private Boolean success;
+
+    /* Result of applying a command to the state machine */
+    private Object response;
+
+    /* If this server is not the leader we have to redirect the request */
+    private Boolean redirect;
+
+    /* Where to redirect the request */
+    private String redirectTo;
+
+}

--- a/reactive/src/main/java/com/springRaft/reactive/communication/outbound/OutboundContext.java
+++ b/reactive/src/main/java/com/springRaft/reactive/communication/outbound/OutboundContext.java
@@ -34,4 +34,9 @@ public class OutboundContext implements OutboundStrategy {
     public Mono<RequestVoteReply> requestVote(String to, RequestVote message) {
         return this.communicationStrategy.requestVote(to,message);
     }
+
+    @Override
+    public Mono<?> request(String command, String location) {
+        return this.communicationStrategy.request(command, location);
+    }
 }

--- a/reactive/src/main/java/com/springRaft/reactive/communication/outbound/OutboundStrategy.java
+++ b/reactive/src/main/java/com/springRaft/reactive/communication/outbound/OutboundStrategy.java
@@ -28,4 +28,15 @@ public interface OutboundStrategy {
      * */
     Mono<RequestVoteReply> requestVote(String to, RequestVote message);
 
+    /**
+     * Abstract method for the outbound strategies implement it, so they can send a general purpose
+     * request to a server on a specific location.
+     *
+     * @param command String that encapsulates the request to invoke.
+     * @param location String that represents the location of the server.
+     *
+     * @return Mono<?> Response object resulting of invoking the request on the specific server.
+     * */
+    Mono<?> request(String command, String location);
+
 }

--- a/reactive/src/main/java/com/springRaft/reactive/communication/outbound/REST.java
+++ b/reactive/src/main/java/com/springRaft/reactive/communication/outbound/REST.java
@@ -36,8 +36,13 @@ public class REST implements OutboundStrategy {
 
     @Override
     public Mono<RequestVoteReply> requestVote(String to, RequestVote message) {
-
         return (Mono<RequestVoteReply>) sendPostToServer(to, "requestVote", message, RequestVoteReply.class);
+    }
+
+    @Override
+    public Mono<?> request(String command, String location) {
+
+        return null;
 
     }
 
@@ -61,7 +66,8 @@ public class REST implements OutboundStrategy {
                 .bodyValue(message)
                 .retrieve()
                 .bodyToMono(type)
-                .timeout(this.raftProperties.getHeartbeat());
+                .timeout(this.raftProperties.getHeartbeat())
+                .subscribeOn(this.scheduler);
     }
 
 }

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/Candidate.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/Candidate.java
@@ -187,6 +187,26 @@ public class Candidate extends RaftStateContext implements RaftState {
     }
 
     @Override
+    public Mono<RequestReply> clientRequest(String command) {
+
+        // When in candidate state, there is nowhere to redirect the request or a leader to
+        // handle them.
+
+        return Mono.defer(() ->
+                Mono.just(
+                        this.applicationContext.getBean(
+                                RequestReply.class, false,
+                                new Object(), false, ""
+                        )
+                )
+        );
+
+        // probably we should store the requests, and redirect them when we became follower
+        // or handle them when became leader
+
+    }
+
+    @Override
     public Mono<Pair<Message, Boolean>> getNextMessage(String to) {
 
         return Mono.defer(() -> Mono.just(new Pair<>(this.requestVoteMessage, false)));

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/ConsensusModule.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/ConsensusModule.java
@@ -61,6 +61,11 @@ public class ConsensusModule implements RaftState {
     }
 
     @Override
+    public Mono<RequestReply> clientRequest(String command) {
+        return this.current.clientRequest(command);
+    }
+
+    @Override
     @Synchronized
     public Mono<Pair<Message, Boolean>> getNextMessage(String to) {
         return this.current.getNextMessage(to);

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/Follower.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/Follower.java
@@ -164,6 +164,21 @@ public class Follower extends RaftStateContext implements RaftState {
     }
 
     @Override
+    public Mono<RequestReply> clientRequest(String command) {
+
+        // When in follower state, we need to redirect the request to the leader
+        return Mono.defer(() ->
+                Mono.just(
+                        this.applicationContext.getBean(
+                                RequestReply.class, false,
+                                new Object(), true, this.leaderId
+                        )
+                )
+        );
+
+    }
+
+    @Override
     public Mono<Pair<Message, Boolean>> getNextMessage(String to) {
 
         return Mono.defer(() -> Mono.just(new Pair<>(null, false)));

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/Leader.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/Leader.java
@@ -198,6 +198,23 @@ public class Leader extends RaftStateContext implements RaftState {
     }
 
     @Override
+    public Mono<RequestReply> clientRequest(String command) {
+
+        // For now it remains like this
+        // but it has to change in order to replicate the request
+        // ...
+        return Mono.defer(() ->
+                Mono.just(
+                        this.applicationContext.getBean(
+                                RequestReply.class, true,
+                                command, false, ""
+                        )
+                )
+        );
+
+    }
+
+    @Override
     public Mono<Pair<Message, Boolean>> getNextMessage(String to) {
 
         return Mono.defer(() ->

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/Leader.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/Leader.java
@@ -13,6 +13,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Scope;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -203,14 +207,22 @@ public class Leader extends RaftStateContext implements RaftState {
         // For now it remains like this
         // but it has to change in order to replicate the request
         // ...
-        return Mono.defer(() ->
-                Mono.just(
-                        this.applicationContext.getBean(
-                                RequestReply.class, true,
-                                command, false, ""
-                        )
-                )
-        );
+        return Mono.defer(() -> {
+
+            HttpHeaders httpHeaders = new HttpHeaders();
+            httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+            Map<String, String> response = new HashMap<>(){{
+                put("command", command);
+            }};
+
+            return Mono.just(
+                    this.applicationContext.getBean(
+                            RequestReply.class, true,
+                            new ResponseEntity<>(response, httpHeaders, HttpStatus.OK), false, ""
+                    )
+            );
+        });
 
     }
 

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/RaftState.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/RaftState.java
@@ -44,6 +44,14 @@ public interface RaftState {
     Mono<Void> requestVoteReply(RequestVoteReply requestVoteReply);
 
     /**
+     * Method for handling the replication of a client request.
+     * @param command String command to replicate and apply to the FSM.
+     *
+     * @return RequestReply Reply for the income request.
+     * */
+    Mono<RequestReply> clientRequest(String command);
+
+    /**
      * Method for getting the next message for a specific server.
      *
      * @param to String that represents the server.


### PR DESCRIPTION
This PR handles client requests, both in an independent and embedded configurations. To accomplish it, this PR adds:

- The RequestReply message;
- The clientRequest method in RaftState and InboundCommunication interfaces, so their specialisations to implement it;
- The Independent Controller;
- The EmbeddedFilter and Embedded Controller;
- Redirection to Leader when the server is not one;