### PR TITLE
Reactive - Entry Replication

### DIFF
--- a/reactive/src/main/java/com/springRaft/reactive/config/WorkerSchedulers.java
+++ b/reactive/src/main/java/com/springRaft/reactive/config/WorkerSchedulers.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import reactor.core.scheduler.Scheduler;
 import reactor.core.scheduler.Schedulers;
 
-
 @Configuration
 public class WorkerSchedulers {
 
@@ -18,18 +17,6 @@ public class WorkerSchedulers {
     public Scheduler generalPurposeScheduler() {
 
         return Schedulers.newBoundedElastic(5, 5, "GeneralScheduler");
-
-    }
-
-    /**
-     * Scheduler for peer workers.
-     *
-     * @return Scheduler dedicated to PeerWorker workers.
-     * */
-    @Bean(name = "peerWorkersScheduler")
-    public Scheduler peerWorkersScheduler() {
-
-        return Schedulers.newBoundedElastic(20, 5, "PeerWorker");
 
     }
 

--- a/reactive/src/main/java/com/springRaft/reactive/config/startup/ConsensusModuleInitialization.java
+++ b/reactive/src/main/java/com/springRaft/reactive/config/startup/ConsensusModuleInitialization.java
@@ -43,8 +43,8 @@ public class ConsensusModuleInitialization implements ApplicationRunner {
 
     @Override
     public void run(ApplicationArguments args) {
-        Mono.just(this.applicationContext.getBean(StateTransition.class, this.applicationContext, this.consensusModule, Follower.class))
-                .doOnNext(this.scheduler::schedule)
+        Mono.just(this.applicationContext.getBean(Follower.class))
+                .flatMap(this.consensusModule::setAndStartNewState)
                 .block();
     }
 

--- a/reactive/src/main/java/com/springRaft/reactive/config/startup/PeerWorkers.java
+++ b/reactive/src/main/java/com/springRaft/reactive/config/startup/PeerWorkers.java
@@ -5,25 +5,28 @@ import com.springRaft.reactive.communication.outbound.OutboundManager;
 import com.springRaft.reactive.config.RaftProperties;
 import com.springRaft.reactive.consensusModule.ConsensusModule;
 import com.springRaft.reactive.worker.PeerWorker;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
+import lombok.AllArgsConstructor;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Scope;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Component
 @Order(2)
+@Scope("singleton")
+@AllArgsConstructor
 public class PeerWorkers implements ApplicationRunner {
 
     /* Application Context for getting beans */
     private final ApplicationContext applicationContext;
-
-    /* Scheduler for submit workers to execution */
-    private final Scheduler scheduler;
 
     /* Raft properties that need to be accessed */
     private final RaftProperties raftProperties;
@@ -31,21 +34,8 @@ public class PeerWorkers implements ApplicationRunner {
     /* Publisher of messages */
     private final OutboundManager outboundManager;
 
-    /* --------------------------------------------------- */
-
-    @Autowired
-    public PeerWorkers(
-            ApplicationContext applicationContext,
-            @Qualifier(value = "peerWorkersScheduler") Scheduler scheduler,
-            RaftProperties raftProperties,
-            OutboundManager outboundManager
-    ) {
-
-        this.applicationContext = applicationContext;
-        this.scheduler = scheduler;
-        this.raftProperties = raftProperties;
-        this.outboundManager = outboundManager;
-    }
+    /* Map containing schedulers for a specific server */
+    private static final Map<String,Scheduler> peerWorkers = new HashMap<>();
 
     /* --------------------------------------------------- */
 
@@ -59,20 +49,47 @@ public class PeerWorkers implements ApplicationRunner {
     public void run(ApplicationArguments args) {
 
         Flux.fromIterable(this.raftProperties.getCluster())
-                .map(server ->
-                        this.applicationContext.getBean(
+                .doOnNext(server -> {
+
+                    // get worker object
+                    PeerWorker worker = this.applicationContext.getBean(
                             PeerWorker.class,
                             this.applicationContext.getBean(OutboundContext.class),
                             this.applicationContext.getBean(ConsensusModule.class),
                             this.raftProperties,
                             server
-                        )
-                )
-                .doOnNext(worker -> {
+                    );
+
+                    // subscribe worker in outbound observer
                     this.outboundManager.subscribe(worker);
-                    this.scheduler.schedule(worker);
+
+                    // Schedule worker on a dedicated scheduler
+                    getPeerWorkerScheduler(server)
+                            .schedule(worker);
+
                 })
                 .blockLast();
+
+    }
+
+    /* --------------------------------------------------- */
+
+    /**
+     * Method that gets a PeerWorker specific scheduler so it can run in the same environment.
+     *
+     * @param worker String that represents the server name.
+     *
+     * @return Scheduler for running the peerWorker.
+     * */
+    public static Scheduler getPeerWorkerScheduler(String worker) {
+
+        Scheduler scheduler = peerWorkers.get(worker);
+        if (scheduler == null) {
+            scheduler = Schedulers.newSingle("PeerWorker");
+            peerWorkers.put(worker, scheduler);
+        }
+
+        return scheduler;
 
     }
 

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/Candidate.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/Candidate.java
@@ -227,7 +227,6 @@ public class Candidate extends RaftStateContext implements RaftState {
 
         return this.transitionManager.setElectionTimeout()
                 .doOnNext(task -> this.scheduledTransition = task)
-                .subscribeOn(Schedulers.single())
                 .then();
 
     }

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/Candidate.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/Candidate.java
@@ -99,9 +99,10 @@ public class Candidate extends RaftStateContext implements RaftState {
                         // update term
                         return this.stateService.setState(requestVote.getTerm(), null)
                                 .flatMap(state -> this.checkLog(requestVote, reply))
-                                .zipWith(
-                                        Mono.zip(this.cleanBeforeTransit(), this.transitionManager.setNewFollowerState()),
-                                        (rvreply, zipTuple) -> rvreply
+                                .flatMap(requestVoteReply ->
+                                        this.cleanBeforeTransit()
+                                            .then(this.transitionManager.setNewFollowerState())
+                                            .then(Mono.just(requestVoteReply))
                                 );
 
 

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/ConsensusModule.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/ConsensusModule.java
@@ -3,10 +3,12 @@ package com.springRaft.reactive.consensusModule;
 import com.springRaft.reactive.communication.message.*;
 import com.springRaft.reactive.util.Pair;
 import lombok.Getter;
-import lombok.Synchronized;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 @Service
 @Scope("singleton")
@@ -16,48 +18,87 @@ public class ConsensusModule implements RaftState {
     /* Current Raft state - Follower, Candidate, Leader */
     private RaftState current;
 
+    /* Mutex for some operations */
+    private final Lock lock;
+
     /* --------------------------------------------------- */
 
     public ConsensusModule() {
         this.current = null;
+        this.lock = new ReentrantLock();
     }
 
     /* --------------------------------------------------- */
+
+    /**
+     * Setter method which sets the new state in consensus module.
+     *
+     * @param state The new raft state of this consensus module.
+     * */
+    public void setCurrentState(RaftState state) {
+        this.current = state;
+    }
 
     /**
      * Setter method which sets the new state in consensus module and starts that state.
      *
      * @param state The new raft state of this consensus module.
      * */
-    public Mono<Void> setCurrentState(RaftState state) {
-        this.current = state;
+    public Mono<Void> setAndStartNewState(RaftState state) {
+        this.setCurrentState(state);
         return this.start();
     }
 
     /* --------------------------------------------------- */
 
     @Override
-    @Synchronized
     public Mono<AppendEntriesReply> appendEntries(AppendEntries appendEntries) {
-        return this.current.appendEntries(appendEntries);
+        return Mono.defer(() -> {
+            lock.lock();
+            return this.current.appendEntries(appendEntries)
+                    .flatMap(reply -> {
+                        lock.unlock();
+                        return Mono.just(reply);
+                    });
+        });
     }
 
     @Override
-    @Synchronized
     public Mono<Void> appendEntriesReply(AppendEntriesReply appendEntriesReply, String from) {
-        return this.current.appendEntriesReply(appendEntriesReply, from);
+        return Mono.defer(() -> {
+            lock.lock();
+            return this.current.appendEntriesReply(appendEntriesReply, from)
+                    .then(Mono.create(monoSink -> {
+                        lock.unlock();
+                        monoSink.success();
+                    }));
+        });
     }
 
     @Override
-    @Synchronized
     public Mono<RequestVoteReply> requestVote(RequestVote requestVote) {
-        return this.current.requestVote(requestVote);
+        return Mono.defer(() -> {
+            lock.lock();
+            return this.current.requestVote(requestVote)
+                    .flatMap(reply ->
+                        Mono.create(monoSink -> {
+                            lock.unlock();
+                            monoSink.success(reply);
+                        })
+                    );
+        });
     }
 
     @Override
-    @Synchronized
     public Mono<Void> requestVoteReply(RequestVoteReply requestVoteReply) {
-        return this.current.requestVoteReply(requestVoteReply);
+        return Mono.defer(() -> {
+            lock.lock();
+                return this.current.requestVoteReply(requestVoteReply)
+                        .then(Mono.create(monoSink -> {
+                            lock.unlock();
+                            monoSink.success();
+                        }));
+        });
     }
 
     @Override
@@ -66,15 +107,27 @@ public class ConsensusModule implements RaftState {
     }
 
     @Override
-    @Synchronized
     public Mono<Pair<Message, Boolean>> getNextMessage(String to) {
-        return this.current.getNextMessage(to);
+        return Mono.defer(() -> {
+            lock.lock();
+            return this.current.getNextMessage(to)
+                    .flatMap(pair -> {
+                        lock.unlock();
+                        return Mono.just(pair);
+                    });
+        });
     }
 
     @Override
-    @Synchronized
     public Mono<Void> start() {
-        return this.current.start();
+        return Mono.defer(() -> {
+            lock.lock();
+            return this.current.start()
+                    .then(Mono.create(monoSink -> {
+                        lock.unlock();
+                        monoSink.success();
+                    }));
+        });
     }
 
 }

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/Follower.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/Follower.java
@@ -165,7 +165,6 @@ public class Follower extends RaftStateContext implements RaftState {
 
         return this.transitionManager.setElectionTimeout()
                 .doOnNext(task -> this.scheduledTransition = task)
-                .subscribeOn(Schedulers.single())
                 .then();
 
     }

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/Follower.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/Follower.java
@@ -94,7 +94,7 @@ public class Follower extends RaftStateContext implements RaftState {
                         // update term
                         return this.stateService.setState(requestVote.getTerm(), null)
                                 .flatMap(state -> this.checkLog(requestVote, reply))
-                                .zipWith(this.cleanBeforeTransit(), (rvreply, clean) -> rvreply);
+                                .flatMap(requestVoteReply -> this.cleanBeforeTransit().then(Mono.just(requestVoteReply)));
 
                     } else {
 

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/Leader.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/Leader.java
@@ -114,10 +114,10 @@ public class Leader extends RaftStateContext implements RaftState {
                                             // clean leader's state
                                             this.cleanVolatileState()
                                     )
-                                    // transit to follower state and
                                     // deactivate PeerWorker
-                                    .then(this.transitionManager.setNewFollowerState())
-                                    .then(this.outboundManager.clearMessages());
+                                    .then(this.outboundManager.clearMessages())
+                                    // transit to follower state
+                                    .then(this.transitionManager.setNewFollowerState());
 
                         } else {
 
@@ -170,8 +170,8 @@ public class Leader extends RaftStateContext implements RaftState {
                                     this.cleanVolatileState();
                                 })
                                 .flatMap(requestVoteReply ->
-                                        this.transitionManager.setNewFollowerState()
-                                            .then(this.outboundManager.clearMessages())
+                                        this.outboundManager.clearMessages()
+                                            .then(this.transitionManager.setNewFollowerState())
                                             .then(Mono.just(requestVoteReply))
                                 );
 
@@ -193,8 +193,8 @@ public class Leader extends RaftStateContext implements RaftState {
                         this.stateService.setState(requestVoteReply.getTerm(), null)
                                 .doOnTerminate(this::cleanVolatileState)
                 )
-                .then(this.transitionManager.setNewFollowerState())
-                .then(this.outboundManager.clearMessages());
+                .then(this.outboundManager.clearMessages())
+                .then(this.transitionManager.setNewFollowerState());
 
     }
 
@@ -293,10 +293,10 @@ public class Leader extends RaftStateContext implements RaftState {
     @Override
     protected Mono<Void> postAppendEntries(AppendEntries appendEntries) {
 
-        // transit to follower state
         // deactivate PeerWorker
-        return this.transitionManager.setNewFollowerState()
-                .then(this.outboundManager.clearMessages())
+        return this.outboundManager.clearMessages()
+                // transit to follower state
+                .then(this.transitionManager.setNewFollowerState())
                 .doFirst(this::cleanVolatileState);
 
 

--- a/reactive/src/main/java/com/springRaft/reactive/consensusModule/TransitionManager.java
+++ b/reactive/src/main/java/com/springRaft/reactive/consensusModule/TransitionManager.java
@@ -68,18 +68,22 @@ public class TransitionManager {
      * Method for creating a new follower state transition which takes place on transition scheduler.
      * */
     public Mono<Void> setNewFollowerState() {
-
-        return Mono.just(applicationContext.getBean(Follower.class)).flatMap(this.consensusModule::setCurrentState);
-
+        return Mono.just(applicationContext.getBean(Follower.class))
+                .flatMap(follower -> {
+                    this.consensusModule.setCurrentState(follower);
+                    return follower.start();
+                });
     }
 
     /**
      * Method for creating a new leader state transition which takes place on transition scheduler.
      * */
     public Mono<Void> setNewLeaderState() {
-
-        return Mono.just(applicationContext.getBean(Leader.class)).flatMap(this.consensusModule::setCurrentState);
-
+        return Mono.just(applicationContext.getBean(Leader.class))
+                .flatMap(leader -> {
+                    this.consensusModule.setCurrentState(leader);
+                    return leader.start();
+                });
     }
 
     /* --------------------------------------------------- */
@@ -93,7 +97,6 @@ public class TransitionManager {
      * @return Mono<Long> Random calculated Long.
      * */
     private Mono<Long> getRandomLongBetweenRange(long min, long max){
-
         return Mono.defer(() -> {
             OptionalLong op = new Random().longs(min, max+1).findFirst();
             return Mono.just(op.isPresent() ? op.getAsLong() : min);

--- a/reactive/src/main/java/com/springRaft/reactive/persistence/log/Entry.java
+++ b/reactive/src/main/java/com/springRaft/reactive/persistence/log/Entry.java
@@ -34,10 +34,11 @@ public class Entry implements Persistable<Long> {
     /**
      * Specific constructor for creating a parametrized entry.
      * */
-    public Entry(Long term, String command) {
+    public Entry(Long term, String command, boolean isNew) {
         this.index = null;
         this.term = term;
         this.command = command;
+        this.isNew = isNew;
     }
 
     /* --------------------------------------------------- */

--- a/reactive/src/main/java/com/springRaft/reactive/persistence/log/EntryRepository.java
+++ b/reactive/src/main/java/com/springRaft/reactive/persistence/log/EntryRepository.java
@@ -38,7 +38,9 @@ public interface EntryRepository extends ReactiveCrudRepository<Entry,Long> {
      * Delete Method for deleting entries with an index greater than a specific number.
      *
      * @param index Long that represents the index from which the following will be deleted.
+     *
+     * @return Integer that represents the elements deleted.
      * */
-    Mono<Void> deleteEntryByIndexGreaterThan(Long index);
+    Mono<Integer> deleteEntryByIndexGreaterThan(Long index);
 
 }

--- a/reactive/src/main/java/com/springRaft/reactive/persistence/log/LogService.java
+++ b/reactive/src/main/java/com/springRaft/reactive/persistence/log/LogService.java
@@ -7,7 +7,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
 
 @Service
 @Scope("singleton")
@@ -77,6 +80,18 @@ public class LogService {
     public Mono<Entry> getLastEntry() {
         return this.entryRepository.findLastEntry()
                 .switchIfEmpty(Mono.just(new Entry((long) 0, (long) 0, null, false)));
+    }
+
+    /**
+     * Method that gets the entries between two indexes.
+     *
+     * @param minIndex Index to begin the search.
+     * @param maxIndex Index to stop the search.
+     *
+     * @return Flux of the Entries found.
+     * */
+    public Flux<Entry> getEntriesBetweenIndexes(Long minIndex, Long maxIndex) {
+        return this.entryRepository.getNextEntries(minIndex, maxIndex);
     }
 
     /**

--- a/reactive/src/main/java/com/springRaft/reactive/persistence/log/LogService.java
+++ b/reactive/src/main/java/com/springRaft/reactive/persistence/log/LogService.java
@@ -110,4 +110,27 @@ public class LogService {
 
     }
 
+    /**
+     * Method that deletes all the log entries with an index greater than a specific value.
+     *
+     * @param index Long that represents the index.
+     *
+     * @return Integer that represents the elements deleted.
+     * */
+    public Mono<Integer> deleteIndexesGreaterThan(Long index) {
+        return this.entryRepository.deleteEntryByIndexGreaterThan(index);
+    }
+
+    /**
+     * Method that saves all the entries in a list.
+     *
+     * @param entries List of entries to save.
+     *
+     * @return Flux<Entry> Entries saved.
+     * */
+    @Synchronized
+    public Flux<Entry> saveAllEntries(List<Entry> entries) {
+        return this.entryRepository.saveAll(entries);
+    }
+
 }

--- a/reactive/src/main/java/com/springRaft/reactive/worker/StateTransition.java
+++ b/reactive/src/main/java/com/springRaft/reactive/worker/StateTransition.java
@@ -28,7 +28,7 @@ public class StateTransition implements Runnable {
 
         // transitions to candidate state
         RaftState raftState = applicationContext.getBean(state);
-        this.consensusModule.setCurrentState(raftState).subscribe();
+        this.consensusModule.setAndStartNewState(raftState).subscribe();
 
     }
 

--- a/reactive/src/main/resources/application-h2.properties
+++ b/reactive/src/main/resources/application-h2.properties
@@ -5,4 +5,5 @@ spring.r2dbc.username=sa
 spring.r2dbc.password=password
 spring.r2dbc.name=raft
 spring.r2dbc.url=r2dbc:h2:mem:///raft
+spring.r2dbc.pool.enabled=true
 spring.r2dbc.pool.max-size=2000


### PR DESCRIPTION
This PR finalizes the Log replication subproblem of Raft. It adds:

- Insertion of an entry in the log;
- Substitution of Zip and ZipWith operators, because they emit no positive signal when some publisher returns Void;
- Conclusion of AppendEntries method in RaftContext;
- Major changes in PeerWorker code, because before it was blocking and imperative and then it is reactive and functional;
- Definition of critical sections in ConsensusModule, so at least on thread at a given time is executing one of the State Machine operations; (locking)
- Consistency in the thread operating in the critical section, so the thread acquiring and releasing a lock has to be the same;

Resolves: #77 