### PR TITLE
Servlet - Refactor

### DIFF
--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/ConsensusModule.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/ConsensusModule.java
@@ -32,16 +32,6 @@ public class ConsensusModule implements RaftState {
         this.current = state;
     }
 
-    /**
-     * Setter method which sets the new state in consensus module and starts that state.
-     *
-     * @param state The new raft state of this consensus module.
-     * */
-    public void setAndStartNewState(RaftState state) {
-        this.setCurrentState(state);
-        this.start();
-    }
-
     /* --------------------------------------------------- */
 
     @Override
@@ -75,7 +65,6 @@ public class ConsensusModule implements RaftState {
     }
 
     @Override
-    @Synchronized
     public void start() {
         this.current.start();
     }
@@ -83,6 +72,19 @@ public class ConsensusModule implements RaftState {
     @Override
     public RequestReply clientRequest(String command) {
         return this.current.clientRequest(command);
+    }
+
+    /* --------------------------------------------------- */
+
+    /**
+     * Setter method which sets the new state in consensus module and starts that state.
+     *
+     * @param state The new raft state of this consensus module.
+     * */
+    @Synchronized
+    public void start(RaftState state) {
+        this.setCurrentState(state);
+        this.start();
     }
 
 }

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/ConsensusModule.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/ConsensusModule.java
@@ -24,10 +24,21 @@ public class ConsensusModule implements RaftState {
     /* --------------------------------------------------- */
 
     /**
-     * TODO
+     * Setter method which sets the new state in consensus module.
+     *
+     * @param state The new raft state of this consensus module.
      * */
     public void setCurrentState(RaftState state) {
         this.current = state;
+    }
+
+    /**
+     * Setter method which sets the new state in consensus module and starts that state.
+     *
+     * @param state The new raft state of this consensus module.
+     * */
+    public void setAndStartNewState(RaftState state) {
+        this.setCurrentState(state);
         this.start();
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/Leader.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/Leader.java
@@ -109,11 +109,11 @@ public class Leader extends RaftStateContext implements RaftState {
                 // clean leader's state
                 this.cleanVolatileState();
 
-                // transit to follower state
-                this.transitionManager.setNewFollowerState();
-
                 // deactivate PeerWorker
                 this.outboundManager.clearMessages();
+
+                // transit to follower state
+                this.transitionManager.setNewFollowerState();
 
             } else {
 
@@ -151,11 +151,11 @@ public class Leader extends RaftStateContext implements RaftState {
 
             this.cleanVolatileState();
 
-            // transit to follower state
-            this.transitionManager.setNewFollowerState();
-
             // deactivate PeerWorker
             this.outboundManager.clearMessages();
+
+            // transit to follower state
+            this.transitionManager.setNewFollowerState();
 
         }
 
@@ -174,11 +174,11 @@ public class Leader extends RaftStateContext implements RaftState {
             // clean leader's state
             this.cleanVolatileState();
 
-            // transit to follower state
-            this.transitionManager.setNewFollowerState();
-
             // deactivate PeerWorker
             this.outboundManager.clearMessages();
+
+            // transit to follower state
+            this.transitionManager.setNewFollowerState();
 
         }
 
@@ -267,11 +267,11 @@ public class Leader extends RaftStateContext implements RaftState {
 
         this.cleanVolatileState();
 
-        // transit to follower state
-        this.transitionManager.setNewFollowerState();
-
         // deactivate PeerWorker
         this.outboundManager.clearMessages();
+
+        // transit to follower state
+        this.transitionManager.setNewFollowerState();
 
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/consensusModule/TransitionManager.java
+++ b/servlet/src/main/java/com/springRaft/servlet/consensusModule/TransitionManager.java
@@ -68,24 +68,14 @@ public class TransitionManager {
      * TODO
      * */
     public void setNewFollowerState() {
-
-        StateTransition transition = applicationContext
-                .getBean(StateTransition.class, applicationContext, consensusModule, Follower.class);
-
-        this.threadPoolTaskScheduler.schedule(transition, new Date());
-
+        this.setNewState(Follower.class);
     }
 
     /**
      * TODO
      * */
     public void setNewLeaderState() {
-
-        StateTransition transition = applicationContext
-                .getBean(StateTransition.class, applicationContext, consensusModule, Leader.class);
-
-        this.threadPoolTaskScheduler.schedule(transition, new Date());
-
+        this.setNewState(Leader.class);
     }
 
     /**
@@ -112,5 +102,14 @@ public class TransitionManager {
         OptionalLong op = new Random().longs(min,(max+1)).findFirst();
 
         return op.isPresent() ? op.getAsLong() : min;
+    }
+
+    /**
+     * TODO
+     * */
+    private void setNewState(Class<? extends RaftState> stateClass) {
+        RaftState state = applicationContext.getBean(stateClass);
+        this.consensusModule.setCurrentState(state);
+        state.start();
     }
 }

--- a/servlet/src/main/java/com/springRaft/servlet/worker/PeerWorker.java
+++ b/servlet/src/main/java/com/springRaft/servlet/worker/PeerWorker.java
@@ -189,8 +189,8 @@ public class PeerWorker implements Runnable, MessageSubscriber {
         } while (reply == null && this.active && this.remainingMessages == 0);
 
         if (reply != null && this.active) {
-            this.consensusModule.requestVoteReply(reply);
             this.clearMessages();
+            this.consensusModule.requestVoteReply(reply);
         }
 
     }
@@ -278,7 +278,7 @@ public class PeerWorker implements Runnable, MessageSubscriber {
         } catch (Exception e) {
 
             // If another exception occurs
-            log.error("Exception not expected in appendEntries method");
+            log.error("Exception not expected in sendRPCHandler method");
 
         }
 

--- a/servlet/src/main/java/com/springRaft/servlet/worker/StateTransition.java
+++ b/servlet/src/main/java/com/springRaft/servlet/worker/StateTransition.java
@@ -1,7 +1,6 @@
 package com.springRaft.servlet.worker;
 
 import com.springRaft.servlet.consensusModule.ConsensusModule;
-import com.springRaft.servlet.consensusModule.Follower;
 import com.springRaft.servlet.consensusModule.RaftState;
 import lombok.AllArgsConstructor;
 import org.springframework.context.ApplicationContext;
@@ -29,7 +28,7 @@ public class StateTransition implements Runnable {
 
         // transitions to candidate state
         RaftState raftState = applicationContext.getBean(state);
-        this.consensusModule.setCurrentState(raftState);
+        this.consensusModule.setAndStartNewState(raftState);
 
     }
 

--- a/servlet/src/main/java/com/springRaft/servlet/worker/StateTransition.java
+++ b/servlet/src/main/java/com/springRaft/servlet/worker/StateTransition.java
@@ -28,7 +28,7 @@ public class StateTransition implements Runnable {
 
         // transitions to candidate state
         RaftState raftState = applicationContext.getBean(state);
-        this.consensusModule.setAndStartNewState(raftState);
+        this.consensusModule.start(raftState);
 
     }
 

--- a/servlet/src/main/resources/application-h2.properties
+++ b/servlet/src/main/resources/application-h2.properties
@@ -1,8 +1,11 @@
 
 # database configurations
 spring.jpa.database=h2
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.open-in-view=false
+
+spring.datasource.platform=h2
 spring.datasource.url=jdbc:h2:mem:raft
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=password
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/servlet/src/main/resources/application-postgres.properties
+++ b/servlet/src/main/resources/application-postgres.properties
@@ -1,8 +1,12 @@
 
 # database configurations
 spring.jpa.database=postgresql
-spring.datasource.platform=postgres
 spring.jpa.hibernate.ddl-auto=update
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.open-in-view=false
+
+spring.datasource.platform=postgres
 spring.datasource.url=jdbc:postgresql://localhost:5432/raft
+spring.datasource.driver-class-name=org.postgresql.Driver
 spring.datasource.username=postgres
 spring.datasource.password=postgres

--- a/servlet/src/main/resources/application.properties
+++ b/servlet/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 # server properties
 server.port=${port:8080}
+server.tomcat.threads.max=${max-threads:2000}
 
 # jackson configurations
 spring.jackson.serialization.FAIL_ON_EMPTY_BEANS=false


### PR DESCRIPTION
This PR refactors some code in the servlet app.

- Arrange properties in the database properties files;
- Change the state transitions logic. Instead of spawning a thread which performs the task, it simply transits instantaneously on the same thread, keeping the logic consistent;
- Increase the maximum number of threads that an application server can spawn. The default was only 200;